### PR TITLE
update scripts.combine_peaks (pandas bug)

### DIFF
--- a/scripts/combine_peaks
+++ b/scripts/combine_peaks
@@ -46,7 +46,18 @@ def combine_peaks(peaks, genome, window, scale_value):
         pass
 
     # Read MACS2 summit files
-    header = ["chrom", "start", "end", "name", "value"]
+    header = [
+        "chrom",
+        "start",
+        "end",
+        "name",
+        "value",
+        "strand",
+        "signalValue",
+        "pval",
+        "qval",
+        "peak",
+    ]
     dfs = [pd.read_table(f, names=header) for f in peaks]
 
     # Combine in one DataFrame
@@ -80,8 +91,10 @@ def combine_peaks(peaks, genome, window, scale_value):
 
     b = BedTool(tmp)
     all_summits = []
+    # loop over merged peaks based on window size and collapse on col4
     for f in b.slop(b=window // 2, g=genome).merge(c=4, o="collapse"):
         summits = [x.split(";") for x in f[3].split(",")]
+        # only keep the peak with the highest summit
         all_summits.append(sorted(summits, key=lambda x: float(x[3]))[-1][:3])
 
     df = pd.DataFrame(all_summits, columns=["chrom", "start", "end"])


### PR DESCRIPTION
I am expecting pandas updated how they handled dataframe indices when not all column names are provided, and combine_peaks didn't work anymore. 

We (me and @mkolmus) solved it simply by explicitly loading all columns (and formatting with black).

I also took the liberty of adding some comments :angel:  