### PR TITLE
fix issue with chrom names as int

### DIFF
--- a/scripts/combine_peaks
+++ b/scripts/combine_peaks
@@ -116,7 +116,7 @@ def combine_peaks(peaks, genome, window, scale_value):
 
     # store summit location + associated value in col4
     df_all["col4"] = (
-        df_all["chrom"]
+        df_all["chrom"].astype(str)
         + ";"
         + df_all["start"].astype(str)
         + ";"


### PR DESCRIPTION
I tried combining peaks from an assembly which chromosome names are ["1", "2", "3", etc], however this gives the error:

```
Traceback (most recent call last):
  File "/vol/mbconda/sande/envs/seq2science/lib/python3.7/site-packages/seq2science/.snakemake/2a3c4b4a/bin/combine_peaks", line 197, in <module>
    df = combine_peaks(args.peaks, args.genome, args.window, args.scale)
  File "/vol/mbconda/sande/envs/seq2science/lib/python3.7/site-packages/seq2science/.snakemake/2a3c4b4a/bin/combine_peaks", line 124, in combine_peaks
    + df_all[check_col].astype(str)
  File "/vol/mbconda/sande/envs/seq2science/lib/python3.7/site-packages/seq2science/.snakemake/2a3c4b4a/lib/python3.7/site-packages/pandas/core/ops/__init__.py", line 1048, in wrapper
    result = na_op(lvalues, rvalues)
  File "/vol/mbconda/sande/envs/seq2science/lib/python3.7/site-packages/seq2science/.snakemake/2a3c4b4a/lib/python3.7/site-packages/pandas/core/ops/__init__.py", line 970, in na_op
    result = masked_arith_op(x, y, op)
  File "/vol/mbconda/sande/envs/seq2science/lib/python3.7/site-packages/seq2science/.snakemake/2a3c4b4a/lib/python3.7/site-packages/pandas/core/ops/__init__.py", line 464, in masked_arith_op
    result[mask] = op(xrav[mask], y)
numpy.core._exceptions.UFuncTypeError: ufunc 'add' did not contain a loop with signature matching types (dtype('<U21'), dtype('<U21')) -> dtype('<U21')
```

This seems to be related to the fact that chromosome names are interpreted as integers. Changing the type to str seems to have solved the case for me :)