### PR TITLE
fix issue with numeric chrom names in combine_peaks

### DIFF
--- a/scripts/combine_peaks
+++ b/scripts/combine_peaks
@@ -46,7 +46,7 @@ def read_peak_file_to_df(fname):
             "qval",
             "peak",
         ]
-        df = pd.read_table(fname, names=header)
+        df = pd.read_table(fname, names=header, dtype={"chrom": "str"})
         df["chrom"] = df["chrom"].astype(str)
 
         # get the summit
@@ -57,7 +57,7 @@ def read_peak_file_to_df(fname):
         df["value"] = df["qval"]
         df = df[summit_header]
     elif ftype == "bed":
-        df = pd.read_table(fname, names=summit_header)
+        df = pd.read_table(fname, names=summit_header, dtype={"chrom": "str"})
         if ((df["end"] - df["start"]) != 1).sum() != 0:
             raise ValueError(f"{fname} does not contain summits.")
     else:


### PR DESCRIPTION
Related to #132. That fix somehow worked for 1 assembly, but for another if failed. No clue why it's inconsistent in its failure:

```
/vol/mbconda/sande/envs/gimme/bin/combine_peaks:198: DtypeWarning: Columns (0) have mixed types.Specify dtype option on import or set low_memory=False.
  df = combine_peaks(args.peaks, args.genome, args.window, args.scale)
Traceback (most recent call last):
  File "/vol/mbconda/sande/envs/gimme/bin/combine_peaks", line 198, in <module>
    df = combine_peaks(args.peaks, args.genome, args.window, args.scale)
  File "/vol/mbconda/sande/envs/gimme/bin/combine_peaks", line 135, in combine_peaks
    for f in b.slop(b=window // 2, g=genome).merge(c=4, o="collapse"):
  File "/vol/mbconda/sande/envs/gimme/lib/python3.7/site-packages/pybedtools/bedtool.py", line 917, in decorated
    result = method(self, *args, **kwargs)
  File "/vol/mbconda/sande/envs/gimme/lib/python3.7/site-packages/pybedtools/bedtool.py", line 401, in wrapped
    decode_output=decode_output,
  File "/vol/mbconda/sande/envs/gimme/lib/python3.7/site-packages/pybedtools/helpers.py", line 455, in call_bedtools
    raise BEDToolsError(subprocess.list2cmdline(cmds), stderr)
pybedtools.helpers.BEDToolsError: 
Command was:

	bedtools merge -o collapse -i /scratch/sande/tmp/pybedtools.0010xysy.tmp -c 4

Error message was:
Error: Sorted input specified, but the file /scratch/sande/tmp/pybedtools.0010xysy.tmp has the following out of order record
1	227228	227429	1;227328;227329;0.0
```

Simply coercing the first column to be interpreted as string fixes that error as well.