### PR TITLE
qnorm 0.4.0, multiprocessing support

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -20,7 +20,7 @@ dependencies:
   - python >=3
   - python-xxhash
   - pyyaml >=3.10
-  - qnorm
+  - qnorm >= 0.4.0
   - represent
   - scikit-learn >=0.18
   - scipy >=1.3.0

--- a/conda_env.dev.txt
+++ b/conda_env.dev.txt
@@ -21,7 +21,7 @@ pysam
 python
 python-xxhash
 pyyaml >=3.10
-qnorm
+qnorm >= 0.4.0
 scikit-learn >=0.23
 scipy >=1.4.1
 seaborn

--- a/conda_env.osx.txt
+++ b/conda_env.osx.txt
@@ -21,7 +21,7 @@ pysam
 python
 python-xxhash
 pyyaml >=3.10
-qnorm
+qnorm >= 0.4.0
 scikit-learn
 scipy
 seaborn

--- a/conda_env.test.txt
+++ b/conda_env.test.txt
@@ -22,7 +22,7 @@ pybedtools
 python >=3.8
 python-xxhash
 pyyaml >=3.10
-qnorm
+qnorm >= 0.4.0
 scikit-learn >=0.18
 scipy <1.3.0
 seaborn

--- a/conda_env.txt
+++ b/conda_env.txt
@@ -22,7 +22,7 @@ pysam
 python >=3
 python-xxhash
 pyyaml >=3.10
-qnorm
+qnorm >= 0.4.0
 scikit-learn >=0.18
 scipy <1.3.0
 seaborn

--- a/scripts/coverage_table
+++ b/scripts/coverage_table
@@ -106,7 +106,8 @@ def make_table(
         df[:] = scale(df, axis=0)
     if normalization == "quantile":
         print("Normalization by quantile normalization", file=sys.stderr)
-        df = qnorm.quantile_normalize(df)
+        # stay between 1-10 ncpus, after 10 diminishing returns
+        df = qnorm.quantile_normalize(df, ncpus=sorted(1, ncpus, 10)[1])
     else:
         print("No normalization", file=sys.stderr)
 

--- a/scripts/coverage_table
+++ b/scripts/coverage_table
@@ -106,8 +106,8 @@ def make_table(
         df[:] = scale(df, axis=0)
     if normalization == "quantile":
         print("Normalization by quantile normalization", file=sys.stderr)
-        # stay between 1-10 ncpus, after 10 diminishing returns
-        df = qnorm.quantile_normalize(df, ncpus=sorted(1, ncpus, 10)[1])
+        # stay between 1-4 ncpus, after 4 highly diminishing returns
+        df = qnorm.quantile_normalize(df, ncpus=sorted(1, ncpus, 4)[1])
     else:
         print("No normalization", file=sys.stderr)
 

--- a/setup.py
+++ b/setup.py
@@ -135,6 +135,6 @@ setup(
         "tqdm",
         "pillow",
         "logomaker",
-        "qnorm",
+        "qnorm >= 0.4.0",
     ],
 )


### PR DESCRIPTION
In an attempt to speed up quantile normalization for a genome in 10bp bins, qnorm now supports parallel sorting. 

More than 4 cpus does not make sense: https://github.com/Maarten-vd-Sande/qnorm#scaling-of-ncpus 