### PR TITLE
Motif2factors from orthologs

### DIFF
--- a/conda_env.dev.txt
+++ b/conda_env.dev.txt
@@ -9,6 +9,7 @@ homer
 ipywidgets  # Necessary for progress bar in Jupyter notebook
 jinja2
 logomaker
+loguru
 matplotlib >=2.0
 meme >=5
 ncurses

--- a/conda_env.osx.txt
+++ b/conda_env.osx.txt
@@ -8,6 +8,7 @@ ghostscript
 homer
 jinja2
 logomaker
+loguru
 llvm-openmp
 matplotlib >=2.0
 meme >=5

--- a/conda_env.test.txt
+++ b/conda_env.test.txt
@@ -11,6 +11,7 @@ icu=58
 ipywidgets  # Necessary for progress bar in Jupyter notebook
 jinja2
 logomaker
+loguru
 matplotlib >=2.0
 meme >=5
 ncurses

--- a/conda_env.txt
+++ b/conda_env.txt
@@ -9,6 +9,7 @@ homer
 ipywidgets  # Necessary for progress bar in Jupyter notebook
 jinja2
 logomaker
+loguru
 matplotlib-base >=3.1.2
 meme >=5.1.1
 ncurses

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -869,8 +869,8 @@ However the main advantage of this method is that it is a easy and fast way to g
 not require any special expertise or infrastructure to work.
 
 The method starts by downloading the genome assemblies of your species-of-interest (new-reference), the species the database is based on
-(database-references), and some other related species for better orthology inference (ortholog-references). From each of these assemblies,
-for each gene the longest protein is taken, and compared with orthofinder for orthology:
+(database-references), and some other related species for better orthology inference (ortholog-references); by default a selection of vertebrate
+species. From each of these assemblies, for each gene the longest protein is taken, and compared with orthofinder for orthology:
 
 .. _`David M. Emms & Steven Kelly 2019`: https://doi.org/10.1186/s13059-019-1832-y
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -21,6 +21,7 @@ List of tools
 * :ref:`gimme threshold<gimme_threshold>`
 * :ref:`gimme location<gimme_location>`
 * :ref:`gimme diff<gimme_diff>`
+* :ref:`gimme motif2factors<gimme_motif2factors>`
 
 
 Input formats
@@ -855,3 +856,45 @@ Compare for instance an FPR of 1% vs an FPR of 5%.
                           BED file with clusters as inputfile.
 
 
+.. _`gimme_motif2factors`:
+
+Command: gimme motif2factors
+-------------------
+
+With motif2factors you can convert an existing motif database to a motif database for your species of interest. This conversion is done by orthology,
+which is not the ideal way to do this. When converting the original database to a database of your favourite critter, only the relations between motifs
+and transcription factors are changed. A method like this; based on orthology is not capable of inferring whether or not the motif has changed.
+
+However the main advantage of this method is that it is a easy and fast way to get a species-specific database, works surprisingly well, and does
+not require any special expertise or infrastructure to work.
+
+The method starts by downloading the genome assemblies of your species-of-interest (new-reference), the species the database is based on
+(database-references), and some other related species for better orthology inference (ortholog-references). From each of these assemblies,
+for each gene the longest protein is taken, and compared with orthofinder for orthology:
+
+.. _`David M. Emms & Steven Kelly 2019`: https://doi.org/10.1186/s13059-019-1832-y
+
+Then based on orthology, we can replace the names of transcription factors in the original database with the names of our new species.
+One problem with this method is that the names of transcription factors in the database not necessarily (necessarily not, bioinformatics...)
+have to overlap with the names used in the genome assembly. To overcome this problem mygene.info is queried to still link differently
+named TFs can still be linked to genes and thus to orthologs. We tested this for gimme.vertebrate.v5.0, and worked well in our case.
+However it might be possible that this generates too many false positives in your case, and you can tweak the lookup on mygene.info
+with the --strict/--medium/--lenient flags.
+
+**Optional arguments:**
+
+::
+
+    --new-reference ASSEMBLY [ASSEMBLY ...]
+                          The assembly the new motif2factors file will be based on.
+    --database db         The database you want to change convert to your species of interest. (default is gimme.vertebrate.v5.0)
+    --database-references ASSEMBLY [ASSEMBLY ...]
+                          The assembly(s) on which the orginal motif2factors is based on. (default is human and mouse)
+    --ortholog-references ASSEMBLY [ASSEMBLY ...]
+                          Extra assemblies for better orthology inference between the new reference and database reference. (default is a range of vertebrate species)
+    --tmpdir DIR          Where to place intermediate files. Defaults to system temp.
+    --outdir OUTDIR       Where to save the results to. Defaults to current working directory.
+    --strict, --medium, --lenient
+                          How strict should the names of the genes in the assembly be followed. Strict: base names only on what is in the annotation file; Medium: base on annotation file, as well as on
+                          mygene.info name and symbol query; Lenient: based on annotation file, and mygeneinfo name, symbol, alias, other_names, accession, accession.protein, refseq, refseq.protein,
+                          ensembl, ensembl.gene. Lenient is the default, but in case of false-positive hits you can tune this stricter.

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -898,3 +898,4 @@ with the --strict/--medium/--lenient flags.
                           How strict should the names of the genes in the assembly be followed. Strict: base names only on what is in the annotation file; Medium: base on annotation file, as well as on
                           mygene.info name and symbol query; Lenient: based on annotation file, and mygeneinfo name, symbol, alias, other_names, accession, accession.protein, refseq, refseq.protein,
                           ensembl, ensembl.gene. Lenient is the default, but in case of false-positive hits you can tune this stricter.
+    --threads INT         Maximum number of parallel threads used.

--- a/gimmemotifs/cli.py
+++ b/gimmemotifs/cli.py
@@ -26,17 +26,19 @@ def cli(sys_args):
 
     epilog = """
     commands:
-        motifs      identify enriched motifs (known and/or de novo)
-        scan        scan for known motifs
-        maelstrom   find differential motifs
-        match       find motif matches in database
-        logo        create sequence logo(s)
-        cluster     cluster similar motifs
-        background  create a background file
-        threshold   calculate motif scan threshold
-        location    motif location histograms
-        diff        compare motif frequency and enrichment
-                    between fasta files
+        motifs          identify enriched motifs (known and/or de novo)
+        scan            scan for known motifs
+        maelstrom       find differential motifs
+        match           find motif matches in database
+        logo            create sequence logo(s)
+        cluster         cluster similar motifs
+        background      create a background file
+        threshold       calculate motif scan threshold
+        location        motif location histograms
+        diff            compare motif frequency and enrichment
+                        between fasta files
+        motif2factors   generate a motif database based on orthology for any
+                        species
 
     type `gimme <command> -h` for more details
     """
@@ -628,6 +630,28 @@ def cli(sys_args):
         metavar="FILE",
     )
     p.set_defaults(func=commands.prediction)
+
+    class Strictness(argparse.Action):
+        def __call__(self, parser, ns, values, option):
+            if
+            setattr(ns, self.dest, "include" in option)
+
+    p = subparsers.add_parser("motif2factors")
+    p.add_argument("--new-reference", help="", metavar="ASSEMBLY")
+    p.add_argument("--ortholog-references", help="", metavar="ASSEMBLY")
+    p.add_argument("--tmpdir", help="", metavar="DIR")
+    p.add_argument("--outdir", help="", metavar="OUTDIR")
+    p.add_argument(
+        "--strict",
+        "--medium",
+        "--lenient",
+        default="lenient",
+        help="",
+        dest="strategy",
+        action=Strictness,
+        nargs=0,
+    )
+    p.set_defaults(func=commands.motif2factors)
 
     if len(sys_args) == 0:
         parser.print_help()

--- a/gimmemotifs/cli.py
+++ b/gimmemotifs/cli.py
@@ -633,20 +633,26 @@ def cli(sys_args):
 
     class Strictness(argparse.Action):
         def __call__(self, parser, ns, values, option):
-            if
-            setattr(ns, self.dest, "include" in option)
+            if "strict" in option:
+                setattr(ns, self.dest, "strict")
+            if "medium" in option:
+                setattr(ns, self.dest, "medium")
+            if "lenient" in option:
+                setattr(ns, self.dest, "lenient")
 
-    p = subparsers.add_parser("motif2factors")
-    p.add_argument("--new-reference", help="", metavar="ASSEMBLY")
-    p.add_argument("--ortholog-references", help="", metavar="ASSEMBLY")
-    p.add_argument("--tmpdir", help="", metavar="DIR")
-    p.add_argument("--outdir", help="", metavar="OUTDIR")
+    p = subparsers.add_parser("motif2factors", help="Generate a motif2factors file based on orthology for your species of interest.")
+    p.add_argument("--new-reference", help="The assembly the new motif2factors file will be based on.", metavar="ASSEMBLY", required=True, nargs="+")
+    p.add_argument("--database", help="The database you want to change convert to your species of interest. (default is gimme.vertebrate.v5.0)", metavar="db", default="gimme.vertebrate.v5.0")
+    p.add_argument("--database-references", help="The assembly(s) on which the orginal motif2factors is based on. (default is human and mouse)", metavar="ASSEMBLY", nargs="+")
+    p.add_argument("--ortholog-references", help="Extra assemblies for better orthology inference between the new reference and database reference. (default is a range of vertebrate species)", metavar="ASSEMBLY", nargs="+")
+    p.add_argument("--tmpdir", help="Where to place intermediate files. Defaults to system temp.", metavar="DIR")
+    p.add_argument("--outdir", help="Where to save the results to. Defaults to current working directory.", metavar="OUTDIR", default=".")
     p.add_argument(
         "--strict",
         "--medium",
         "--lenient",
         default="lenient",
-        help="",
+        help="How strict should the names of the genes in the assembly be followed. Strict: base names only on what is in the annotation file; Medium: base on annotation file, as well as on mygene.info name and symbol query; Lenient: based on annotation file, and mygeneinfo name, symbol, alias, other_names, accession, accession.protein, refseq, refseq.protein, ensembl, ensembl.gene. Lenient is the default, but in case of false-positive hits you can tune this stricter.",
         dest="strategy",
         action=Strictness,
         nargs=0,

--- a/gimmemotifs/cli.py
+++ b/gimmemotifs/cli.py
@@ -657,6 +657,7 @@ def cli(sys_args):
         action=Strictness,
         nargs=0,
     )
+    p.add_argument("--threads", help="Maximum number of parallel threads used.", metavar="INT", default=24)
     p.set_defaults(func=commands.motif2factors)
 
     if len(sys_args) == 0:

--- a/gimmemotifs/commands/motif2factors.py
+++ b/gimmemotifs/commands/motif2factors.py
@@ -14,7 +14,7 @@ def motif2factors(args):
         "outdir": args.outdir,
         "strategy": args.strategy,
         "database": args.database,
-        "threads": args.threads
+        "threads": args.threads,
     }
     kwargs = {k: v for k, v in kwargs.items() if v is not None}
     motif2factor_from_orthologs(**kwargs)

--- a/gimmemotifs/commands/motif2factors.py
+++ b/gimmemotifs/commands/motif2factors.py
@@ -7,10 +7,12 @@ from gimmemotifs.orthologs import motif2factor_from_orthologs
 
 
 def motif2factors(args):
-    motif2factor_from_orthologs(
-        new_reference=args.new_reference,
-        extra_orthologs_references=args.new_reference,
-        tmpdir=args.genomes_dir,
-        outdir=args.outdir,
-        strategy=args.strategy
-    )
+    kwargs = {
+        "new_reference": args.new_reference,
+        "extra_orthologs_references": args.ortholog_references,
+        "tmpdir": args.tmpdir,
+        "outdir": args.outdir,
+        "strategy": args.strategy
+    }
+    kwargs = {k: v for k, v in kwargs.items() if v is not None}
+    motif2factor_from_orthologs(**kwargs)

--- a/gimmemotifs/commands/motif2factors.py
+++ b/gimmemotifs/commands/motif2factors.py
@@ -12,7 +12,9 @@ def motif2factors(args):
         "extra_orthologs_references": args.ortholog_references,
         "tmpdir": args.tmpdir,
         "outdir": args.outdir,
-        "strategy": args.strategy
+        "strategy": args.strategy,
+        "database": args.database,
+        "threads": args.threads
     }
     kwargs = {k: v for k, v in kwargs.items() if v is not None}
     motif2factor_from_orthologs(**kwargs)

--- a/gimmemotifs/commands/motif2factors.py
+++ b/gimmemotifs/commands/motif2factors.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2009-2021 Simon van Heeringen <simon.vanheeringen@gmail.com>
+#
+# This module is free software. You can redistribute it and/or modify it under
+# the terms of the MIT License, see the file COPYING included with this
+# distribution.
+from gimmemotifs.orthologs import motif2factor_from_orthologs
+
+
+def motif2factors(args):
+    motif2factor_from_orthologs(
+        new_reference=args.new_reference,
+        extra_orthologs_references=args.new_reference,
+        tmpdir=args.genomes_dir,
+        outdir=args.outdir,
+        strategy=args.strategy
+    )

--- a/gimmemotifs/orthologs.py
+++ b/gimmemotifs/orthologs.py
@@ -32,21 +32,21 @@ RENAME_TFS = {"NR1A4": "NR4A1", "SREBP1a": "SREBF1"}
 
 
 def motif2factor_from_orthologs(
-        database: str = "gimme.vertebrate.v5.0",
-        database_references: List[str] = ["GRCh38.p13", "GRCm38.p6"],
-        extra_orthologs_references: List[str] = [
-            "danRer11",
-            "UCB_Xtro_10.0",
-            "GRCg6a",
-            "BraLan2",
-            "ASM318616v1",
-            "Astyanax_mexicanus-2.0",
-            "oryLat2",
-        ],
-        new_reference: List[str] = None,
-        genomes_dir: str = None,
-        tmpdir: str = None,
-        outdir: str = ".",
+    database: str = "gimme.vertebrate.v5.0",
+    database_references: List[str] = ["GRCh38.p13", "GRCm38.p6"],
+    extra_orthologs_references: List[str] = [
+        "danRer11",
+        "UCB_Xtro_10.0",
+        "GRCg6a",
+        "BraLan2",
+        "ASM318616v1",
+        "Astyanax_mexicanus-2.0",
+        "oryLat2",
+    ],
+    new_reference: List[str] = None,
+    genomes_dir: str = None,
+    tmpdir: str = None,
+    outdir: str = ".",
 ):
     """
 
@@ -111,7 +111,7 @@ def _download_genomes_with_annot(genomes, genomes_dir):
     """
     no_annotations = [genome for genome in genomes if not _has_annotation(genome)]
     assert (
-            len(no_annotations) == 0
+        len(no_annotations) == 0
     ), f"genome(s): {','.join(no_annotations)} seem not to have an annotation for it."
 
     # download the genomes
@@ -260,7 +260,7 @@ def load_orthogroups_in_db(db, genomes, orthofinder_result):
     # all genes per species
     for assembly in genomes:
         for orthogroup, genes in zip(
-                orthogroups["HOG"], orthogroups[f"{assembly}.pep"]
+            orthogroups["HOG"], orthogroups[f"{assembly}.pep"]
         ):
             if isinstance(genes, float) and np.isnan(genes):
                 continue
@@ -372,14 +372,19 @@ def factor2orthogroups(factor, references, database):
 
     # if still none found, we try a very broad myinfo query (higher chance of false positive)
     if len(orthogroups) == 0:
-        gene_symbols = _unknownfactor2symbols(factor, fields=["alias",
-                                                              "other_names",
-                                                              "accession",
-                                                              "accession.protein",
-                                                              "refseq",
-                                                              "refseq.protein",
-                                                              "ensembl",
-                                                              "ensembl.gene", ])
+        gene_symbols = _unknownfactor2symbols(
+            factor,
+            fields=[
+                "alias",
+                "other_names",
+                "accession",
+                "accession.protein",
+                "refseq",
+                "refseq.protein",
+                "ensembl",
+                "ensembl.gene",
+            ],
+        )
         for gene_symbol in gene_symbols:
             orthogroups += _factor2orthogroups_sql(gene_symbol, references, database)
 
@@ -392,7 +397,7 @@ def factor2orthogroups(factor, references, database):
 
 
 def make_motif2factors(
-        outfile, new_reference, database_references, motifsandfactors, database
+    outfile, new_reference, database_references, motifsandfactors, database
 ):
     conn = sqlite3.connect(database)
     cur = conn.cursor()

--- a/gimmemotifs/orthologs.py
+++ b/gimmemotifs/orthologs.py
@@ -33,7 +33,7 @@ FASTA_LINEWIDTH = 80
 BLACKLIST_TFS = [
     "dobox4",  # does not exist
     "dobox5",  # does not exist
-    "foxa",    # not sure which FOXA(1,2,3)
+    "foxa",  # not sure which FOXA(1,2,3)
     "ep300",
 ]
 RENAME_TFS = {"NR1A4": "NR4A1", "SREBP1a": "SREBF1"}
@@ -43,20 +43,20 @@ def motif2factor_from_orthologs(
     database: str = "gimme.vertebrate.v5.0",
     database_references: List[str] = ["GRCh38.p13", "GRCm38.p6"],
     extra_orthologs_references: List[str] = [
-        "danRer11",          # zebrafish
-        "UCB_Xtro_10.0",     # xenopus
-        "GRCg6a",            # chicken
-        "BraLan2",           # lancet fish (out-group ish)
-        "oryLat2",           # medaka
-        "ARS-UCD1.2",        # cow
+        "danRer11",  # zebrafish
+        "UCB_Xtro_10.0",  # xenopus
+        "GRCg6a",  # chicken
+        "BraLan2",  # lancet fish (out-group ish)
+        "oryLat2",  # medaka
+        "ARS-UCD1.2",  # cow
         "phaCin_unsw_v4.1",  # koala
-        "rCheMyd1.pri",      # turtle
+        "rCheMyd1.pri",  # turtle
     ],
     new_reference: List[str] = None,
     tmpdir: str = None,
     outdir: str = ".",
     strategy: str = "lenient",
-    threads: int = 24
+    threads: int = 24,
 ):
     """
     Make a motifs2factors file based on gene orthology.
@@ -76,8 +76,12 @@ def motif2factor_from_orthologs(
     tmpdir = tempfile.mkdtemp() if tmpdir is None else tmpdir
 
     logger.info(f"Making a new reference for: {' & '.join(new_reference)}.")
-    logger.info(f"You say the {database} database is based on: {' & '.join(database_references)}.")
-    logger.info(f"For better orthology inference we are also using these assemblies: {' & '.join(extra_orthologs_references)}.")
+    logger.info(
+        f"You say the {database} database is based on: {' & '.join(database_references)}."
+    )
+    logger.info(
+        f"For better orthology inference we are also using these assemblies: {' & '.join(extra_orthologs_references)}."
+    )
     logger.info(f"Using strategy: {strategy} for orthology/name inference.")
     logger.info(f"tmpdir: {tmpdir}.")
     logger.info(f"outdir: {outdir}.")
@@ -119,7 +123,7 @@ def motif2factor_from_orthologs(
             motifsandfactors=motifsandfactors,
             database=orthogroup_db,
             strategy=strategy,
-            motifs=motifs
+            motifs=motifs,
         )
 
     # cleanup
@@ -130,7 +134,7 @@ def _check_install():
     dependencies = ["gffread", "orthofinder"]
     if any(shutil.which(dependency) is None for dependency in dependencies):
         logger.warning(
-f"""Running gimme motif2factors requires {" & ".join(dependencies)} to be installed.
+            f"""Running gimme motif2factors requires {" & ".join(dependencies)} to be installed.
 
 You can easily install these dependencies with conda in the environment where gimmemotifs is installed:
 conda install {" ".join(dependencies)}"""
@@ -144,7 +148,7 @@ def _orthofinder(peptide_folder, threads):
     """
     # run orthofinder on the primary transcripts
     result = subprocess.run(
-        [f"orthofinder", f"-f", peptide_folder, "-t", threads], capture_output=True
+        ["orthofinder", "-f", peptide_folder, "-t", threads], capture_output=True
     )
 
     logger.debug(f"""stdout of orthofinder:\n {result.stdout.decode("utf-8")}""")
@@ -170,17 +174,22 @@ def _download_genomes_with_annot(genomes, genomes_dir):
     for genome in genomes:
         # check if already in default genomes dir, if so, skip downloading and directly copy
         if all(
-                os.path.exists(f"{default_genomes_dir}/{genome}/{genome}.{extension}") for extension in ["fa", "annotation.gtf"]
+            os.path.exists(f"{default_genomes_dir}/{genome}/{genome}.{extension}")
+            for extension in ["fa", "annotation.gtf"]
         ):
             logger.info(f"{genome} was already downloaded, using that version.")
             # if except, probably a continuation from previous run
             try:
                 os.mkdir(f"{genomes_dir}/{genome}")
-                os.symlink(f"{default_genomes_dir}/{genome}/{genome}.fa",
-                           f"{genomes_dir}/{genome}/{genome}.fa")
-                os.symlink(f"{default_genomes_dir}/{genome}/{genome}.annotation.gtf",
-                           f"{genomes_dir}/{genome}/{genome}.annotation.gtf")
-            except:
+                os.symlink(
+                    f"{default_genomes_dir}/{genome}/{genome}.fa",
+                    f"{genomes_dir}/{genome}/{genome}.fa",
+                )
+                os.symlink(
+                    f"{default_genomes_dir}/{genome}/{genome}.annotation.gtf",
+                    f"{genomes_dir}/{genome}/{genome}.annotation.gtf",
+                )
+            except Exception:
                 pass
         else:
             logger.info(f"Downloading {genome} through genomepy.")
@@ -212,15 +221,15 @@ def annot2primpep(genome, outdir):
     # use gffread to convert our annotation.gtf into all possible peptides
     result = subprocess.run(
         [
-            f"gffread",
-            f"-y",
+            "gffread",
+            "-y",
             f"{outdir}/{genome}/{genome}.pep.fa",
-            f"-g",
+            "-g",
             f"{outdir}/{genome}/{genome}.fa",
             f"{outdir}/{genome}/{genome}.annotation.gtf",
-            f"-S",
-            f"--table",
-            f"gene_name,gene_id",
+            "-S",
+            "--table",
+            "gene_name,gene_id",
         ],
         capture_output=True,
     )
@@ -242,7 +251,9 @@ def annot2primpep(genome, outdir):
         # skip proteins with stop codon
         # (probably mitochondrial protein since they have a different codon table)
         if "*" in protein:
-            logger.debug(f"skipping {prot_name} since it contains a * symbol (probably mitochondrial read).")
+            logger.debug(
+                f"skipping {prot_name} since it contains a * symbol (probably mitochondrial read)."
+            )
             continue
 
         # skip when we already have a longer edition of the same gene
@@ -257,7 +268,7 @@ def annot2primpep(genome, outdir):
         for record, sequence in records.items():
             f.write(f">{record}\n")
             f.write("\n".join(wrap(sequence, width=FASTA_LINEWIDTH)))
-            f.write(f"\n")
+            f.write("\n")
 
 
 def load_orthogroups_in_db(db, genomes, orthofinder_result):
@@ -283,7 +294,7 @@ def load_orthogroups_in_db(db, genomes, orthofinder_result):
         """
         CREATE TABLE IF NOT EXISTS orthogroups
         (
-        id integer PRIMARY KEY, 
+        id integer PRIMARY KEY,
         orthogroup text UNIQUE NOT NULL
         )
         """
@@ -293,7 +304,7 @@ def load_orthogroups_in_db(db, genomes, orthofinder_result):
         """
         CREATE TABLE IF NOT EXISTS assemblies
         (
-        id integer PRIMARY KEY, 
+        id integer PRIMARY KEY,
         assembly text
         )
         """
@@ -320,7 +331,7 @@ def load_orthogroups_in_db(db, genomes, orthofinder_result):
     # all orthogroups
     for orthogroup in orthogroups["HOG"]:  # <-- all Hierarchical OrthoGroups
         conn.execute(f"INSERT INTO orthogroups VALUES(NULL, '{orthogroup}')")
-    conn.execute(f"INSERT INTO orthogroups VALUES(NULL, 'UNASSIGNED')")
+    conn.execute("INSERT INTO orthogroups VALUES(NULL, 'UNASSIGNED')")
 
     # all assemblies
     for assembly in genomes:
@@ -378,7 +389,13 @@ def load_orthogroups_in_db(db, genomes, orthofinder_result):
 
 
 def make_motif2factors(
-    prefix, new_reference, database_references, motifsandfactors, database, strategy, motifs
+    prefix,
+    new_reference,
+    database_references,
+    motifsandfactors,
+    database,
+    strategy,
+    motifs,
 ):
     """
     Make a motifs2factors file based on an existing ortholog database.
@@ -392,7 +409,7 @@ def make_motif2factors(
     cur = conn.cursor()
 
     with open(f"{prefix}.motif2factors.txt", "w") as f:
-        f.write(f"Motif\tFactor\tEvidence\tCurated\n")
+        f.write("Motif\tFactor\tEvidence\tCurated\n")
         for motif, factors in motifsandfactors.items():
             # remember if we found any orthologs for all the factors belonging
             # to our motif
@@ -429,7 +446,6 @@ def make_motif2factors(
             print(motif.to_pwm(), file=f)
 
 
-
 @lru_cache(maxsize=99999)
 def factor2orthogroups(factor, references, database, strategy):
     """
@@ -459,7 +475,9 @@ def factor2orthogroups(factor, references, database, strategy):
         if len(orthogroups) == 0:
             gene_symbols = _unknownfactor2symbols(factor, fields=["name", "symbol"])
             for gene_symbol in gene_symbols:
-                orthogroups += _factor2orthogroups_sql(gene_symbol, references, database)
+                orthogroups += _factor2orthogroups_sql(
+                    gene_symbol, references, database
+                )
 
     # if still none found, we try a very broad myinfo query (higher chance of false positive)
     if strategy in ["lenient"]:
@@ -478,7 +496,9 @@ def factor2orthogroups(factor, references, database, strategy):
                 ],
             )
             for gene_symbol in gene_symbols:
-                orthogroups += _factor2orthogroups_sql(gene_symbol, references, database)
+                orthogroups += _factor2orthogroups_sql(
+                    gene_symbol, references, database
+                )
 
     orthogroups = list(set(orthogroups))
 
@@ -497,8 +517,8 @@ def _factor2orthogroups_sql(factor, references, database):
 
     orthogroups = list()
     res = cur.execute(
-        f"SELECT orthogroup FROM genes "
-        f"WHERE ("
+        "SELECT orthogroup FROM genes "
+        "WHERE ("
         + " OR ".join(f"assembly='{assembly}'" for assembly in references)
         + ")"
         + f"    AND (gene_name_lower='{factor.lower()}' OR gene_id_lower='{factor.lower()}')"
@@ -514,6 +534,7 @@ def _unknownfactor2symbols(factor, fields):
     """
     Query mygeneinfo for different aliases of our gene
     """
+
     def mygeneinfo(field):
         request = f"http://mygene.info/v3/query?q={field}:{factor}&fields=entrezgene,name,symbol,taxid,other_names,ensembl.gene"
         try:
@@ -533,13 +554,15 @@ def _unknownfactor2symbols(factor, fields):
     for hit in hits:
         for field in ["alias", "name", "symbol", "ensembl"]:
             if field in hit:
-                if not "'" in hit[field]:
+                if "'" not in hit[field]:
                     if field == "ensembl" and "gene" in hit[field]:
                         symbols.add(hit[field]["gene"])
                     else:
                         symbols.add(hit[field])
                 elif isinstance(hit[field], list):
-                    symbols.update({each["gene"] for each in hit[field] if "gene" in each})
+                    symbols.update(
+                        {each["gene"] for each in hit[field] if "gene" in each}
+                    )
     return list(symbols)
 
 

--- a/gimmemotifs/orthologs.py
+++ b/gimmemotifs/orthologs.py
@@ -1,3 +1,8 @@
+"""
+Make a new motifs2factors file based on orthology. This gets complicated
+because not all factors in the motifs2factors file are based on gene names;
+some factors are gene ids, and some are aliases or other symbols.
+"""
 import os
 import re
 import json

--- a/gimmemotifs/orthologs.py
+++ b/gimmemotifs/orthologs.py
@@ -1,0 +1,365 @@
+import os
+import re
+import json
+import urllib
+import sqlite3
+import pathlib
+import tempfile
+import subprocess
+import multiprocessing.dummy
+from typing import List
+from textwrap import wrap
+from functools import lru_cache
+from urllib.error import HTTPError
+
+import pyfaidx
+import logging
+import genomepy
+import numpy as np
+import pandas as pd
+
+# TODO: actually use logger
+logger = logging.getLogger("gimme.orthologs")
+
+FASTA_LINEWIDTH = 80
+BLACKLIST_TFS = [
+    "Dobox4",  # does not exist
+    "Dobox5",  # does not exist
+    "FOXA"  # not sure which FOXA(1,2,3)
+]
+RENAME_TFS = {
+    "NR1A4": "NR4A1",
+    "SREBP1a": "SREBF1"
+}
+
+
+def motif2factor_from_orthologs(
+        database: str = "gimme.vertebrate.v5.0",
+        database_references: List[str] = ["GRCh38.p13", "GRCm38.p6"],
+        extra_orthologs_references: List[str] = ["danRer11",
+                                                 "UCB_Xtro_10.0",
+                                                 "GRCg6a",
+                                                 "BraLan2",
+                                                 "ASM318616v1",
+                                                 "Astyanax_mexicanus-2.0",
+                                                 "oryLat2"],
+        new_reference: List[str] = None,
+        genomes_dir: str = None,
+        tmpdir: str = None,
+        outdir: str = "."
+):
+    """
+
+    """
+    all_genomes = set(database_references + extra_orthologs_references + new_reference)
+
+    # TODO set outdir from args
+    # outdir = tempfile.mkdtemp(dir=tmpdir)
+    outdir = "/vol/gimmetest"
+    genomes_dir = genomes_dir if genomes_dir is not None else outdir
+
+    #     # download all required genomes
+    #     _download_genomes_with_annot(all_genomes, genomes_dir)
+
+    #     # convert each genome + annotation into the primary transcripts (longest protein per gene)
+    #     for genome in all_genomes:
+    #         annot2primpep(genome, outdir)
+
+    #     # run ortho...
+    #     orthofinder_result = _orthofinder(f"{outdir}/prim_genes")
+
+    # now parse the output of orthofinder
+    # TODO remove
+    orthofinder_result = "/vol/gimmetest/prim_genes/OrthoFinder/Results_Feb12"
+    orthogroup_db = f"{outdir}/orthologs.sqlite"
+    load_orthogroups_in_db(orthogroup_db, all_genomes, orthofinder_result)
+
+    # get all motifs and related factors from motif database
+    motifs = read_motifs(database)
+    motifsandfactors = {motif.id: [val for sublist in motif.factors.values() for val in sublist] for motif in motifs}
+
+    # process the references
+    for genome in new_reference:
+        make_motif2factors(f"{outdir}/{genome}.{database}.pfm", new_reference=genome,
+                           database_references=database_references, motifsandfactors=motifsandfactors,
+                           database=orthogroup_db)
+
+
+def _orthofinder(peptide_folder):
+    # run orthofinder on the primary transcripts
+    result = subprocess.run([f"orthofinder",
+                             f"-f",
+                             peptide_folder],
+                            capture_output=True)
+
+    # TODO error handling
+    print(result.stdout.decode("utf-8"))
+    print(result.stderr.decode("utf-8"))
+
+    orthofinder_result = re.search("Results:\n    (.*)", result.stdout.decode("utf-8")).group(1)
+    return orthofinder_result
+
+
+def _download_genomes_with_annot(genomes, genomes_dir):
+    """
+    """
+    no_annotations = [genome for genome in genomes if not _has_annotation(genome)]
+    assert len(no_annotations) == 0, f"genome(s): {','.join(no_annotations)} seem not to have an annotation for it."
+
+    # download the genomes
+    # add check to see if not already in genomes dir?
+    for genome in genomes:
+        genomepy.install_genome(genome, annotation=True, genomes_dir=genomes_dir)
+        result = subprocess.run(["gunzip",
+                                 f"{genomes_dir}/{genome}/{genome}.annotation.gtf.gz"],
+                                capture_output=True)
+        # TODO errors
+
+
+def annot2primpep(genome, outdir):
+    """
+    """
+    # setup our result folder
+    pathlib.Path(f"{outdir}/prim_genes").mkdir(parents=True, exist_ok=True)
+
+    # for each genome, make a .pep.fa. This pep.fa contains the LONGEST protein for each gene
+    # use gffread to convert our annotation.gtf into all possible peptides
+    result = subprocess.run([f"gffread",
+                             f"-y",
+                             f"{outdir}/{genome}/{genome}.pep.fa",
+                             f"-g",
+                             f"{outdir}/{genome}/{genome}.fa",
+                             f"{outdir}/{genome}/{genome}.annotation.gtf",
+                             f"-S",
+                             f"--table",
+                             f"gene_name,gene_id"],
+                            capture_output=True)
+    # TODO error handling
+    print(genome)
+    print(result.stdout.decode("utf-8"))
+    print(result.stderr.decode("utf-8"))
+
+    # read the resulting .pep.fa
+    proteins = pyfaidx.Fasta(f"{outdir}/{genome}/{genome}.pep.fa", read_long_names=True)
+
+    # and only keep the longest protein per gene
+    records = dict()
+    for record in proteins:
+        # get the gene name and gene id of the protein
+        prot_name = "|".join(record.long_name.split("\t")[1:])
+        #         prot_name = record.long_name.split("\t")[1]
+        #         # if no gene name reported, take the gene id
+        #         if prot_name == ".":
+        #             prot_name = record.long_name.split("\t")[2]
+
+        # get the protein sequence
+        protein = str(record)
+
+        # skip proteins with stop codon
+        # (probably mitochondrial protein since they have a different codon table)
+        # TODO report this?
+        if "*" in protein:
+            continue
+
+        # skip when we already have a longer edition of the same gene
+        if prot_name in records and len(records[prot_name]) > len(protein):
+            continue
+
+        # add to our records
+        records[prot_name] = protein
+
+    with open(f"{outdir}/prim_genes/{genome}.pep.fa", 'w') as f:
+        for record, sequence in records.items():
+            f.write(f">{record}\n")
+            f.write("\n".join(wrap(sequence, width=FASTA_LINEWIDTH)))
+            f.write(f"\n")
+
+
+def _has_annotation(genome):
+    """
+    Return True if a genome has an annotation for it, else False
+    """
+    providers = [genomepy.ProviderBase.create(provider) for provider in ["ensembl", "ucsc", "ncbi"]]
+    for provider in providers:
+        if genome in provider.genomes:
+            link = provider.get_annotation_download_link(genome)
+            return link is not None
+    return False
+
+
+def load_orthogroups_in_db(db, genomes, orthofinder_result):
+    orthogroups = pd.read_table(f"{orthofinder_result}/Phylogenetic_Hierarchical_Orthogroups/N0.tsv")
+    unassigned = pd.read_table(f"{orthofinder_result}/Orthogroups/Orthogroups_UnassignedGenes.tsv")
+
+    if os.path.exists(db):
+        os.remove(db)
+    conn = sqlite3.connect(db)
+    conn.execute("""
+                 CREATE TABLE IF NOT EXISTS orthogroups
+                 (
+                 id integer PRIMARY KEY, 
+                 orthogroup text UNIQUE NOT NULL
+                 )
+                 """)
+
+    conn.execute("""
+                 CREATE TABLE IF NOT EXISTS assemblies
+                 (
+                 id integer PRIMARY KEY, 
+                 assembly text
+                 )
+                 """)
+
+    conn.execute("""
+                 CREATE TABLE IF NOT EXISTS genes
+                 (
+                 id integer PRIMARY KEY,
+                 gene text NOT NULL,
+                 gene_lower text NOT NULL,
+                 assembly NOT NULL,
+                 orthogroup,
+                 FOREIGN KEY (orthogroup) REFERENCES orthogroups (id),
+                 FOREIGN KEY (assembly) REFERENCES assemblies (assembly)
+                 )
+                 """)
+
+    # fill in our database
+    # all orthogroups
+    for orthogroup in orthogroups["HOG"]:
+        conn.execute(f"INSERT INTO orthogroups VALUES(NULL, '{orthogroup}')")
+    conn.execute(f"INSERT INTO orthogroups VALUES(NULL, 'UNASSIGNED')")
+
+    # all assemblies
+    for assembly in genomes:
+        conn.execute(f"INSERT INTO assemblies VALUES(NULL, '{assembly}')")
+
+    # all genes per species
+    for assembly in genomes:
+        for orthogroup, genes in zip(orthogroups["HOG"], orthogroups[f"{assembly}.pep"]):
+            if isinstance(genes, float) and np.isnan(genes):
+                continue
+
+            for gene in genes.split(", "):
+                gene_name, gene_id = gene.split("|")
+                if gene_name != ".":
+                    conn.execute(
+                        f"INSERT INTO genes VALUES(NULL, '{gene_name}', '{gene_name.lower()}', '{assembly}', '{orthogroup}')")
+                if gene_id != ".":
+                    conn.execute(
+                        f"INSERT INTO genes VALUES(NULL, '{gene_id}', '{gene_id.lower()}', '{assembly}', '{orthogroup}')")
+
+    # also add unasigned genes
+    for assembly in all_genomes:
+        for gene in unassigned[f"{assembly}.pep"]:
+            if isinstance(gene, float) and np.isnan(gene):
+                continue
+
+            conn.execute(f"INSERT INTO genes VALUES(NULL, '{gene}', '{gene.lower()}', '{assembly}', NULL)")
+
+    conn.commit()
+    cur = conn.cursor()
+
+    cur.execute("CREATE INDEX idx_gene_lower ON genes (gene_lower, assembly)")
+    cur.execute("CREATE INDEX idx_gene ON genes (gene)")
+    #     cur.execute("CREATE INDEX idx_orthogroup ON orthogroups (orthogroup)")
+    cur.execute("CREATE INDEX idx_orthogroup_assembly ON genes (orthogroup, assembly)")
+    conn.commit()
+
+    return db
+
+
+def _unknownfactor2symbols(factor):
+    """
+
+    """
+
+    def mygeneinfo(field):
+        request = f"http://mygene.info/v3/query?q={field}:{factor}&fields=entrezgene,name,symbol,taxid,other_names"
+        try:
+            with urllib.request.urlopen(request) as url:
+                data = json.loads(url.read().decode())
+                return data["hits"]
+        except HTTPError:
+            return list()
+
+    fields = ["alias", "name", "other_names", "accession", "accession.protein", "refseq", "refseq.protein", "ensembl",
+              "ensembl.gene", "symbol"]
+    p = multiprocessing.dummy.Pool(len(fields))
+    hits = p.map(mygeneinfo, fields)
+    hits = [item for sublist in hits for item in sublist]
+    symbols = set()
+    for hit in hits:
+        for field in ["alias", "name", "symbol"]:
+            if field in hit and not "'" in hit[field]:
+                symbols.add(hit[field])
+    return list(symbols)
+
+
+def _factor2orthogroups_sql(factor, references, database):
+    """
+
+    """
+    conn = sqlite3.connect(database)
+    cur = conn.cursor()
+
+    orthogroups = list()
+    res = cur.execute(
+        f"SELECT orthogroup FROM genes "
+        f"WHERE (" + " OR ".join(f"assembly='{assembly}'" for assembly in references) + ")" +
+        f"    AND gene_lower='{factor.lower()}'"
+    ).fetchall()
+
+    for orthogroup in res:
+        if orthogroup is not None:
+            orthogroups.append(*orthogroup)
+    return orthogroups
+
+
+@lru_cache(maxsize=99999)
+def factor2orthogroups(factor, references, database):
+    if factor in BLACKLIST_TFS:
+        return []
+
+    if factor in RENAME_TFS:
+        factor = RENAME_TFS[factor]
+
+    # see if the factor is in the original database
+    orthogroups = _factor2orthogroups_sql(factor, references, database)
+
+    # if not, check if we can find anything by quering mygene.info
+    if len(orthogroups) == 0:
+        gene_symbols = _unknownfactor2symbols(factor)
+        for gene_symbol in gene_symbols:
+            orthogroups += _factor2orthogroups_sql(gene_symbol, references, database)
+
+        orthogroups = list(set(orthogroups))
+
+    if len(orthogroups) == 0:
+        print(factor)
+
+    return orthogroups
+
+
+def make_motif2factors(outfile, new_reference, database_references, motifsandfactors, database):
+    conn = sqlite3.connect(database)
+    cur = conn.cursor()
+
+    with open(outfile, "w") as f:
+        f.write(f"Motif\tFactor\tEvidence\tCurated\n")
+        for motif, factors in motifsandfactors.items():
+            motif_set = False
+            orthologousgroups = {item for factor in factors for item in
+                                 factor2orthogroups(factor, tuple(database_references), database)}
+            #             print(factors, orthologousgroups)
+            if len(orthologousgroups) > 0:
+                for orthologousgroup in orthologousgroups:
+                    res = cur.execute(
+                        f"SELECT * FROM genes WHERE orthogroup='{orthologousgroup}' AND assembly='{new_reference}'"
+                    ).fetchall()
+
+                    if len(res):
+                        for _, gene, gene_lower, assembly, orthogroup in res:
+                            motif_set = True
+                            f.write(f"{motif}\t{gene}\tOrthologs\tN\n")
+            if not motif_set:
+                f.write(f"{motif}\tNO ORTHOLOGS FOUND\tOrthologs\tN\n")

--- a/gimmemotifs/orthologs.py
+++ b/gimmemotifs/orthologs.py
@@ -35,13 +35,16 @@ def motif2factor_from_orthologs(
     database: str = "gimme.vertebrate.v5.0",
     database_references: List[str] = ["GRCh38.p13", "GRCm38.p6"],
     extra_orthologs_references: List[str] = [
-        "danRer11",
-        "UCB_Xtro_10.0",
-        "GRCg6a",
-        "BraLan2",
-        "ASM318616v1",
-        "Astyanax_mexicanus-2.0",
-        "oryLat2",
+        "danRer11",  # zebrafish
+        "UCB_Xtro_10.0",  # xenopus
+        "GRCg6a",  # chicken
+        "BraLan2",  # lancet fish (out-group ish)
+        "ASM318616v1",  # turbot
+        "Astyanax_mexicanus-2.0",  # cave fish
+        "oryLat2",  # medaka
+        "ARS-UCD1.2",  # cow
+        "phaCin_unsw_v4.1",  # koala
+        "rCheMyd1.pri",  # turtle
     ],
     new_reference: List[str] = None,
     genomes_dir: str = None,
@@ -49,10 +52,21 @@ def motif2factor_from_orthologs(
     outdir: str = ".",
 ):
     """
+    Make a motifs2factors file based on gene ortology.
 
+    This function first downloads the genomes of the new reference, the old
+    reference (human and mouse), and a wide range of different vertebrate
+    genomes (a range of genomes is necessary to get a better ortolog inference)
+
+    Then the peptide sequence of each gene is extracted from the genome +
+    annotation, and ortologs between these are derived by orthofinder.
+
+    Finally, based on these ortologs, a new motifs2factors file is created from
+    the old one.
     """
     all_genomes = set(database_references + extra_orthologs_references + new_reference)
 
+    # TODO use tmpdir
     # TODO set outdir from args
     # outdir = tempfile.mkdtemp(dir=tmpdir)
     outdir = "/vol/gimmetest"
@@ -61,11 +75,11 @@ def motif2factor_from_orthologs(
     # download all required genomes
     _download_genomes_with_annot(all_genomes, genomes_dir)
 
-    # convert each genome + annotation into the primary transcripts (longest protein per gene)
+    # convert each genome + annotation into the primary genes (longest protein per gene)
     for genome in all_genomes:
         annot2primpep(genome, outdir)
 
-    # run ortho...
+    # run orthofinder on our primary genes
     orthofinder_result = _orthofinder(f"{outdir}/prim_genes")
 
     # now parse the output of orthofinder
@@ -91,6 +105,9 @@ def motif2factor_from_orthologs(
 
 
 def _orthofinder(peptide_folder):
+    """
+    Run orthofinder on the peptide folder
+    """
     # run orthofinder on the primary transcripts
     result = subprocess.run(
         [f"orthofinder", f"-f", peptide_folder], capture_output=True
@@ -107,8 +124,7 @@ def _orthofinder(peptide_folder):
 
 
 def _download_genomes_with_annot(genomes, genomes_dir):
-    """
-    """
+    # make sure each genome has a gene annotation
     no_annotations = [genome for genome in genomes if not _has_annotation(genome)]
     assert (
         len(no_annotations) == 0
@@ -122,11 +138,20 @@ def _download_genomes_with_annot(genomes, genomes_dir):
             ["gunzip", f"{genomes_dir}/{genome}/{genome}.annotation.gtf.gz"],
             capture_output=True,
         )
-        # TODO errors
+        # TODO error handling
 
 
 def annot2primpep(genome, outdir):
     """
+    Go from a gene annotation (gtf) to a primary proteins file. Uses gffread to
+    do the heavy lifting.
+
+    The gene identifier of the fasta consists of both the gene name and the
+    gene id, separated by a pipe symbol, like so:
+
+    >GATA4|ENSG00000136574
+    MYQSLAMAANHGPPPGAYEAGGPGAFMHGAGAASSPVYVPTPR
+    GTQQGSPGWSQAGADGAAYTPPPVSPRFSFPGTTGSLAAAAAA
     """
     # setup our result folder
     pathlib.Path(f"{outdir}/prim_genes").mkdir(parents=True, exist_ok=True)
@@ -177,6 +202,7 @@ def annot2primpep(genome, outdir):
         # add to our records
         records[prot_name] = protein
 
+    # and finally save our result
     with open(f"{outdir}/prim_genes/{genome}.pep.fa", "w") as f:
         for record, sequence in records.items():
             f.write(f">{record}\n")
@@ -184,22 +210,14 @@ def annot2primpep(genome, outdir):
             f.write(f"\n")
 
 
-def _has_annotation(genome):
-    """
-    Return True if a genome has an annotation for it, else False
-    """
-    providers = [
-        genomepy.ProviderBase.create(provider)
-        for provider in ["ensembl", "ucsc", "ncbi"]
-    ]
-    for provider in providers:
-        if genome in provider.genomes:
-            link = provider.get_annotation_download_link(genome)
-            return link is not None
-    return False
-
-
 def load_orthogroups_in_db(db, genomes, orthofinder_result):
+    """
+    Save the results of orthofinder (tsv file) in a relational database
+    (SQLite). This makes it possible to easily switch between genes and
+    ortogroups.
+
+    We create three tables; genes, ortogroups, and assemblies.
+    """
     orthogroups = pd.read_table(
         f"{orthofinder_result}/Phylogenetic_Hierarchical_Orthogroups/N0.tsv"
     )
@@ -207,49 +225,50 @@ def load_orthogroups_in_db(db, genomes, orthofinder_result):
         f"{orthofinder_result}/Orthogroups/Orthogroups_UnassignedGenes.tsv"
     )
 
+    # remove old db if it exists (TODO: shouldnt be necessary?)
     if os.path.exists(db):
         os.remove(db)
     conn = sqlite3.connect(db)
     conn.execute(
         """
-                 CREATE TABLE IF NOT EXISTS orthogroups
-                 (
-                 id integer PRIMARY KEY, 
-                 orthogroup text UNIQUE NOT NULL
-                 )
-                 """
+        CREATE TABLE IF NOT EXISTS orthogroups
+        (
+        id integer PRIMARY KEY, 
+        orthogroup text UNIQUE NOT NULL
+        )
+        """
     )
 
     conn.execute(
         """
-                 CREATE TABLE IF NOT EXISTS assemblies
-                 (
-                 id integer PRIMARY KEY, 
-                 assembly text
-                 )
-                 """
+        CREATE TABLE IF NOT EXISTS assemblies
+        (
+        id integer PRIMARY KEY, 
+        assembly text
+        )
+        """
     )
 
     conn.execute(
         """
-                 CREATE TABLE IF NOT EXISTS genes
-                 (
-                 id integer PRIMARY KEY,
-                 gene_name text,
-                 gene_name_lower text,
-                 gene_id text,
-                 gene_id_lower text,
-                 assembly NOT NULL,
-                 orthogroup,
-                 FOREIGN KEY (orthogroup) REFERENCES orthogroups (id),
-                 FOREIGN KEY (assembly) REFERENCES assemblies (assembly)
-                 )
-                 """
+        CREATE TABLE IF NOT EXISTS genes
+        (
+        id integer PRIMARY KEY,
+        gene_name text,
+        gene_name_lower text,
+        gene_id text,
+        gene_id_lower text,
+        assembly NOT NULL,
+        orthogroup,
+        FOREIGN KEY (orthogroup) REFERENCES orthogroups (id),
+        FOREIGN KEY (assembly) REFERENCES assemblies (assembly)
+        )
+        """
     )
 
-    # fill in our database
+    # fill up our database
     # all orthogroups
-    for orthogroup in orthogroups["HOG"]:
+    for orthogroup in orthogroups["HOG"]:  # <-- all Hierarchical OrthoGroups
         conn.execute(f"INSERT INTO orthogroups VALUES(NULL, '{orthogroup}')")
     conn.execute(f"INSERT INTO orthogroups VALUES(NULL, 'UNASSIGNED')")
 
@@ -266,8 +285,9 @@ def load_orthogroups_in_db(db, genomes, orthofinder_result):
                 continue
 
             for gene in genes.split(", "):
+                # for each gene we store its gene_name (if present,
+                # otherwise .) and gene_id. We load them both in the database.
                 gene_name, gene_id = gene.split("|")
-                #                 print(gene, gene_name, gene_id, gene_name != ".", orthogroup)
                 if gene_name != ".":
                     conn.execute(
                         f"INSERT INTO genes VALUES(NULL, '{gene_name}', '{gene_name.lower()}', '{gene_id}', '{gene_id.lower()}', '{assembly}', '{orthogroup}')"
@@ -283,6 +303,8 @@ def load_orthogroups_in_db(db, genomes, orthofinder_result):
             if isinstance(gene, float) and np.isnan(gene):
                 continue
 
+            # for each gene we store its gene_name (if present,
+            # otherwise .) and gene_id. We load them both in the database.
             gene_name, gene_id = gene.split("|")
             if gene_name != ".":
                 conn.execute(
@@ -296,65 +318,79 @@ def load_orthogroups_in_db(db, genomes, orthofinder_result):
     conn.commit()
     cur = conn.cursor()
 
+    # now make some indices to make it fast!
     cur.execute("CREATE INDEX idx_name_lower ON genes (gene_name_lower, assembly)")
     cur.execute("CREATE INDEX idx_id_lower ON genes (gene_id_lower, assembly)")
-    #     cur.execute("CREATE INDEX idx_gene ON genes (gene)")
-    #     cur.execute("CREATE INDEX idx_orthogroup ON orthogroups (orthogroup)")
     cur.execute("CREATE INDEX idx_orthogroup_assembly ON genes (orthogroup, assembly)")
     conn.commit()
 
     return db
 
 
-def _unknownfactor2symbols(factor, fields):
+def make_motif2factors(
+    outfile, new_reference, database_references, motifsandfactors, database
+):
     """
+    Make a motifs2factors file based on an existing ortolog database.
 
+    We loop over each motif, find which factors belong to it in the old
+    reference, then find all the orthogroups those belong to, and finally assign
+    all the genes of the new reference species that belong to those orthogroups.
+
+    However
     """
-
-    def mygeneinfo(field):
-        request = f"http://mygene.info/v3/query?q={field}:{factor}&fields=entrezgene,name,symbol,taxid,other_names"
-        try:
-            with urllib.request.urlopen(request) as url:
-                data = json.loads(url.read().decode())
-                return data["hits"]
-        except HTTPError:
-            return list()
-
-    p = multiprocessing.dummy.Pool(len(fields))
-    hits = p.map(mygeneinfo, fields)
-    hits = [item for sublist in hits for item in sublist]
-    symbols = set()
-    for hit in hits:
-        for field in ["alias", "name", "symbol"]:
-            if field in hit and not "'" in hit[field]:
-                symbols.add(hit[field])
-    return list(symbols)
-
-
-def _factor2orthogroups_sql(factor, references, database):
-    """
-
-    """
+    factor2orthogroups.cache_clear()
     conn = sqlite3.connect(database)
     cur = conn.cursor()
 
-    orthogroups = list()
-    res = cur.execute(
-        f"SELECT orthogroup FROM genes "
-        f"WHERE ("
-        + " OR ".join(f"assembly='{assembly}'" for assembly in references)
-        + ")"
-        + f"    AND (gene_name_lower='{factor.lower()}' OR gene_id_lower='{factor.lower()}')"
-    ).fetchall()
+    with open(outfile, "w") as f:
+        f.write(f"Motif\tFactor\tEvidence\tCurated\n")
+        for motif, factors in motifsandfactors.items():
+            # remember if we found any orthologs for all the factors belonging
+            # to our motif
+            motif_set = False
 
-    for orthogroup in res:
-        if orthogroup is not None:
-            orthogroups.append(*orthogroup)
-    return orthogroups
+            # get all the orthogroups belonging to all our factors belonging to
+            # our motif. This is not as trivial as it sounds, since gene naming
+            # is a mess
+            orthologousgroups = {
+                item
+                for factor in factors
+                for item in factor2orthogroups(
+                    factor, tuple(database_references), database
+                )
+            }
+            if len(orthologousgroups) > 0:
+                for orthologousgroup in orthologousgroups:
+                    res = cur.execute(
+                        f"SELECT * FROM genes WHERE orthogroup='{orthologousgroup}' AND assembly='{new_reference}'"
+                    ).fetchall()
+
+                    if len(res):
+                        for _, gene_name, _, gene_id, *_ in res:
+                            motif_set = True
+                            if gene_name is not None:
+                                f.write(f"{motif}\t{gene_name}\tOrthologs\tN\n")
+                            else:
+                                f.write(f"{motif}\t{gene_id}\tOrthologs\tN\n")
+            if not motif_set:
+                f.write(f"{motif}\tNO ORTHOLOGS FOUND\tOrthologs\tN\n")
 
 
 @lru_cache(maxsize=99999)
 def factor2orthogroups(factor, references, database):
+    """
+    Returns all the orthogroups a factor belongs to. This is NOT a trivial task.
+
+    Some of the factors shouldn't be considered (blacklisted), some have an
+    ambiguous name that should be renamed, and in general the factor naming is
+    inconsistent.
+
+    We first check whether or not it fits in our ortogroup database (easy!), if
+    not, we start querying mygeneinfo to get more gene aliases to search for in
+    our ortogroups. If that didn't work we query mygeneinfo again, but with a
+    **very** lenient query, and hope that works.
+    """
     if factor in BLACKLIST_TFS:
         return []
 
@@ -390,42 +426,72 @@ def factor2orthogroups(factor, references, database):
 
     orthogroups = list(set(orthogroups))
 
+    # TODO what to do with these cases?
     if len(orthogroups) == 0:
         print(factor)
 
     return orthogroups
 
 
-def make_motif2factors(
-    outfile, new_reference, database_references, motifsandfactors, database
-):
+def _factor2orthogroups_sql(factor, references, database):
+    """
+    Query our sql database for all orthogroups a factor belongs to
+    """
     conn = sqlite3.connect(database)
     cur = conn.cursor()
 
-    with open(outfile, "w") as f:
-        f.write(f"Motif\tFactor\tEvidence\tCurated\n")
-        for motif, factors in motifsandfactors.items():
-            motif_set = False
-            orthologousgroups = {
-                item
-                for factor in factors
-                for item in factor2orthogroups(
-                    factor, tuple(database_references), database
-                )
-            }
-            #             print(factors, orthologousgroups)
-            if len(orthologousgroups) > 0:
-                for orthologousgroup in orthologousgroups:
-                    res = cur.execute(
-                        f"SELECT * FROM genes WHERE orthogroup='{orthologousgroup}' AND assembly='{new_reference}'"
-                    ).fetchall()
+    orthogroups = list()
+    res = cur.execute(
+        f"SELECT orthogroup FROM genes "
+        f"WHERE ("
+        + " OR ".join(f"assembly='{assembly}'" for assembly in references)
+        + ")"
+        + f"    AND (gene_name_lower='{factor.lower()}' OR gene_id_lower='{factor.lower()}')"
+    ).fetchall()
 
-                    if len(res):
-                        for _, gene_name, _, gene_id, *_ in res:
-                            motif_set = True
-                            if gene_name is not None:
-                                f.write(f"{motif}\t{gene_name}\tOrthologs\tN\n")
-                            else:
-                                f.write(f"{motif}\t{gene_id}\tOrthologs\tN\n")
-            if not motif_set:
-                f.write(f"{motif}\tNO ORTHOLOGS FOUND\tOrthologs\tN\n")
+    for orthogroup in res:
+        if orthogroup is not None:
+            orthogroups.append(*orthogroup)
+    return orthogroups
+
+
+def _unknownfactor2symbols(factor, fields):
+    """
+    Query mygeneinfo for different aliases of our gene
+    """
+
+    def mygeneinfo(field):
+        request = f"http://mygene.info/v3/query?q={field}:{factor}&fields=entrezgene,name,symbol,taxid,other_names"
+        try:
+            with urllib.request.urlopen(request) as url:
+                data = json.loads(url.read().decode())
+                return data["hits"]
+        except HTTPError:
+            return list()
+
+    # multithreaded to do multiple queries at once
+    p = multiprocessing.dummy.Pool(len(fields))
+    hits = p.map(mygeneinfo, fields)
+    hits = [item for sublist in hits for item in sublist]
+    symbols = set()
+    # only keep aliases, gene names and HGNC symbols
+    for hit in hits:
+        for field in ["alias", "name", "symbol"]:
+            if field in hit and not "'" in hit[field]:
+                symbols.add(hit[field])
+    return list(symbols)
+
+
+def _has_annotation(genome):
+    """
+    Return True if a genome has an annotation for it, else False
+    """
+    providers = [
+        genomepy.ProviderBase.create(provider)
+        for provider in ["ensembl", "ucsc", "ncbi"]
+    ]
+    for provider in providers:
+        if genome in provider.genomes:
+            link = provider.get_annotation_download_link(genome)
+            return link is not None
+    return False

--- a/gimmemotifs/orthologs.py
+++ b/gimmemotifs/orthologs.py
@@ -78,6 +78,9 @@ def motif2factor_from_orthologs(
     logger.info(f"The original motif2factors is based on: {' & '.join(database_references)}.")
     logger.info(f"For better orthology inference we are also using these assemblies: {' & '.join(extra_orthologs_references)}.")
     logger.info(f"Using strategy: {strategy} for orthology/name inference.")
+    logger.info(f"tmpdir: {tmpdir}.")
+    logger.info(f"outdir: {outdir}.")
+
     all_genomes = set(database_references + extra_orthologs_references + new_reference)
 
     # download all required genomes
@@ -169,11 +172,15 @@ def _download_genomes_with_annot(genomes, genomes_dir):
                 os.path.exists(f"{default_genomes_dir}/{genome}/{genome}.{extension}") for extension in ["fa", "annotation.gtf"]
         ):
             logger.info(f"{genome} was already downloaded, using that version.")
-            os.mkdir(f"{genomes_dir}/{genome}")
-            os.symlink(f"{default_genomes_dir}/{genome}/{genome}.fa",
-                       f"{genomes_dir}/{genome}/{genome}.fa")
-            os.symlink(f"{default_genomes_dir}/{genome}/{genome}.annotation.gtf",
-                       f"{genomes_dir}/{genome}/{genome}.annotation.gtf")
+            # if except, probably a continuation from previous run
+            try:
+                os.mkdir(f"{genomes_dir}/{genome}")
+                os.symlink(f"{default_genomes_dir}/{genome}/{genome}.fa",
+                           f"{genomes_dir}/{genome}/{genome}.fa")
+                os.symlink(f"{default_genomes_dir}/{genome}/{genome}.annotation.gtf",
+                           f"{genomes_dir}/{genome}/{genome}.annotation.gtf")
+            except:
+                pass
         else:
             logger.info(f"Downloading {genome} through genomepy.")
             genomepy.install_genome(genome, annotation=True, genomes_dir=genomes_dir)
@@ -420,7 +427,7 @@ def make_motif2factors(
 
     with open(f"{prefix}.pfm", "w") as f:
         for motif in motifs:
-            print(motif.to_pfm(), file=f)
+            print(motif.to_pwm(), file=f)
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -137,5 +137,6 @@ setup(
         "pillow",
         "logomaker",
         "qnorm",
+        "loguru",
     ],
 )


### PR DESCRIPTION
Get a motif2factors file based on orthologs. My idea would be to build this into gimmemotifs, as a new command.  

To do:

- [x] name of command, e.g. `gimme motif2factors`
- [x] which species as (default) reference (orthodb advices somewhere between 4-8 I believe)
- [x] test if this also works on non-gimmemotifs database (e.g. jaspar)
- [x] test on ananse + docs for ananse (https://github.com/vanheeringen-lab/ANANSE/projects/4#card-54237974)
- [x] clean up code
  - [x] generic
  - [x] how do we log for shell commands, should I use the logger?
- [x] docs 
- [ ] update the current gimme motif database and remove the _unclear_ factors 
- [ ] support non-vertebrate?
