### PR TITLE
Update stats.py

### DIFF
--- a/gimmemotifs/stats.py
+++ b/gimmemotifs/stats.py
@@ -347,7 +347,8 @@ def write_stats(stats, fname, header=None):
         f.write("{}\t{}\n".format("Motif", "\t".join(stat_keys)))
 
         for motif in stats:
-            m_stats = stats.get(str(motif), {}).get(bg)
+            motif = str(motif)
+            m_stats = stats.get(motif, {}).get(bg)
             if m_stats:
                 f.write(
                     "{}\t{}\n".format(
@@ -357,7 +358,7 @@ def write_stats(stats, fname, header=None):
                 )
             else:
                 logger.warn(
-                    "No stats for motif {0}, skipping this motif!".format(motif.id)
+                    "No stats for motif {0}, skipping this motif!".format(motif)
                 )
             # motifs.remove(motif)
         f.close()


### PR DESCRIPTION
Potential fix for Angela's bug:
```
Traceback (most recent call last):
 File "/mbshome/acanosancho/miniconda3/envs/gimme/bin/gimme", line 11, in <module>
  cli(sys.argv[1:])
 File "/mbshome/acanosancho/miniconda3/envs/gimme/lib/python3.8/site-packages/gimmemotifs/cli.py", line 661, in cli
  args.func(args)
 File "/mbshome/acanosancho/miniconda3/envs/gimme/lib/python3.8/site-packages/gimmemotifs/commands/motifs.py", line 104, in motifs  
  gimme_motifs(
 File "/mbshome/acanosancho/miniconda3/envs/gimme/lib/python3.8/site-packages/gimmemotifs/denovo.py", line 682, in gimme_motifs
  create_denovo_motif_report(
 File "/mbshome/acanosancho/miniconda3/envs/gimme/lib/python3.8/site-packages/gimmemotifs/report.py", line 804, in create_denovo_motif_report
  _create_text_report(inputfile, motifs, closest_match, stats, outdir)
 File "/mbshome/acanosancho/miniconda3/envs/gimme/lib/python3.8/site-packages/gimmemotifs/report.py", line 660, in _create_text_report
  write_stats(my_stats, os.path.join(outdir, "stats.{}.txt"), header=header)
 File "/mbshome/acanosancho/miniconda3/envs/gimme/lib/python3.8/site-packages/gimmemotifs/stats.py", line 360, in write_stats
  "No stats for motif {0}, skipping this motif!".format(motif.id)
AttributeError: 'str' object has no attribute 'id'
```