### PR TITLE
continuously update queue

### DIFF
--- a/gimmemotifs/scanner.py
+++ b/gimmemotifs/scanner.py
@@ -1168,7 +1168,7 @@ class Scanner(object):
         if self.ncpus > 1:
             k = 0
             chunksize = len(batchsize) // self.ncpus + 1
-            max_queue_size = 5 * self.ncpus
+            max_queue_size = 1 * self.ncpus
             jobs = []
             for i in range(math.ceil(len(scan_seqs) / chunksize)):
                 batch_seqs = scan_seqs[i * chunksize : (i + 1) * chunksize]


### PR DESCRIPTION
Initial tests seem to make `gimme scan` +/- 25% faster by updating the queue online. It **seems** to not have an effect on memory usage. 


new implementtation:

```
	User time (seconds): 10842.61
	System time (seconds): 89.40
	Percent of CPU this job got: 935%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 19:29.19
	Maximum resident set size (kbytes): 760520
```

vs

old implementation:

```
	User time (seconds): 10953.35
	System time (seconds): 101.56
	Percent of CPU this job got: 693%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 26:33.91
	Maximum resident set size (kbytes): 775536
```

According to `line_profiler` the actual `_scan_jobs` function takes +/- 65% of the time of the previous implementation.

@simonvh Does this get tested by gimmemotifs CI? I did a quick scan by checking if the shasum was the same with the old and new method, but I don't feel confident that it works with only that as a test :smile: 