### PR TITLE
added --genomes_dir flag to gimme motif2factors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ website/**/*
 .pytest_cache/
 .cache/
 **/.ipynb_checkpoints/
+.idea/
 .vscode
 .coverage*
 coverage.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+* Added `--genomes_dir` argument to `gimme motif2factors`.
+
 ### Changed
 
 ### Fixed
+
+* `gimme motif2factors` can now unzip genome fastas.
+* `gimme motif2factors` will will sanitize genome names.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 * `gimme motif2factors` can now unzip genome fastas.
-* `gimme motif2factors` will will sanitize genome names.
+* `gimme motif2factors` will sanitize genome names.
 
 ### Removed
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -879,24 +879,25 @@ One problem with this method is that the names of transcription factors in the d
 have to overlap with the names used in the genome assembly. To overcome this problem mygene.info is queried to still link differently
 named TFs can still be linked to genes and thus to orthologs. We tested this for gimme.vertebrate.v5.0, and worked well in our case.
 However it might be possible that this generates too many false positives in your case, and you can tweak the lookup on mygene.info
-with the --strict/--medium/--lenient flags.
+with the ``--strict``/``--medium``/``--lenient`` flags.
 
 If you happen to work with e.g. a non-public genome or a genome with a different type of annotation, you can supply your own files.
 This can either be:
 
 * a fasta and gtf file with the naming schemes
 
-  * `{genomes_dir}/{genome_name}/{genome_name}.fa`
+  * ``{genomes_dir}/{genome_name}/{genome_name}.fa``
 
-  * `{genomes_dir}/{genome_name}/{genome_name}.annotation.gtf`
+  * ``{genomes_dir}/{genome_name}/{genome_name}.annotation.gtf``
 
 * a peptide file with the naming scheme
 
-  * `{genomes_dir}/{genome_name}/{genome_name}.pep.fa`
+  * ``{genomes_dir}/{genome_name}/{genome_name}.pep.fa``
 
-The `genomes_dir` can be specified on the command line, else the default gimmemotifs genome dir is used
-(use `genomepy config show` to get this location).
-The `genome_name` can be the name of the assembly/genome you use, e.g. hg38 for human.
+The ``genome_name`` can be the name of the assembly/genome you use, e.g. hg38 for human.
+The ``genomes_dir`` can optionally be specified on the command line. 
+Otherwise the default genomes dir is used (use `genomepy config show` to get this location).
+If one or more genomes were previously installed with genomepy, their full path can be used as well (regardless of the ``genomes_dir``). 
 The peptide file should be of the format:
 
 ::

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -881,15 +881,30 @@ named TFs can still be linked to genes and thus to orthologs. We tested this for
 However it might be possible that this generates too many false positives in your case, and you can tweak the lookup on mygene.info
 with the --strict/--medium/--lenient flags.
 
-If you happen to work with e.g. a non-public genome or a genome with a different type of annotation, you can supply your own peptide
-file that the command can work with. You should store that file under `{genome_dir}/{genome_name}/{genome_name}.pep.fa`, where the
-`genome_dir` is the default gimmemotifs genome dir (use `genomepy config show` to get this location), and the `genome_name` the name
-of the assembly/genome you use, e.g. hg38 for human. The peptide file should be of the format:
+If you happen to work with e.g. a non-public genome or a genome with a different type of annotation, you can supply your own files.
+This can either be:
 
->identifier1
-MKNTMKKQSGVVDTFKKAITAKSQWHDKDEFLDVIYWFKQIIGVILGLLWGFIPLKGFLG
->identifier2
-MRPLRIIIQRKGKSYGELHGYGQIYKSKMPVSKILLAVNEKRNNHNNISILDDFRRVSSI
+* a fasta and gtf file with the naming schemes
+
+  * `{genomes_dir}/{genome_name}/{genome_name}.fa`
+
+  * `{genomes_dir}/{genome_name}/{genome_name}.annotation.gtf`
+
+* a peptide file with the naming scheme
+
+  * `{genomes_dir}/{genome_name}/{genome_name}.pep.fa`
+
+The `genomes_dir` can be specified on the command line, else the default gimmemotifs genome dir is used
+(use `genomepy config show` to get this location).
+The `genome_name` can be the name of the assembly/genome you use, e.g. hg38 for human.
+The peptide file should be of the format:
+
+::
+
+    >identifier1
+    MKNTMKKQSGVVDTFKKAITAKSQWHDKDEFLDVIYWFKQIIGVILGLLWGFIPLKGFLG
+    >identifier2
+    MRPLRIIIQRKGKSYGELHGYGQIYKSKMPVSKILLAVNEKRNNHNNISILDDFRRVSSI
 
 where the identifier can be any
 
@@ -910,6 +925,7 @@ and gimmemotifs will use key 1. Usually 1 represents the gene_name, 2 the gene_i
                           The assembly(s) on which the orginal motif2factors is based on. (default is human and mouse)
     --ortholog-references ASSEMBLY [ASSEMBLY ...]
                           Extra assemblies for better orthology inference between the new reference and database reference. (default is a range of vertebrate species)
+    --genomes_dir DIR     Where to find/store genomepy genomes. Defaults to the genomepy config settings.
     --tmpdir DIR          Where to place intermediate files. Defaults to system temp.
     --outdir OUTDIR       Where to save the results to. Defaults to current working directory.
     --strict, --medium, --lenient

--- a/gimmemotifs/cli.py
+++ b/gimmemotifs/cli.py
@@ -670,6 +670,11 @@ def cli(sys_args):
         nargs="+",
     )
     p.add_argument(
+        "--genomes_dir",
+        help="Where to find/store genomepy genomes. Defaults to the genomepy config settings.",
+        metavar="DIR",
+    )
+    p.add_argument(
         "--tmpdir",
         help="Where to place intermediate files. Defaults to system temp.",
         metavar="DIR",

--- a/gimmemotifs/commands/motif2factors.py
+++ b/gimmemotifs/commands/motif2factors.py
@@ -10,6 +10,7 @@ def motif2factors(args):
     kwargs = {
         "new_reference": args.new_reference,
         "extra_orthologs_references": args.ortholog_references,
+        "genomes_dir": args.genomes_dir,
         "tmpdir": args.tmpdir,
         "outdir": args.outdir,
         "strategy": args.strategy,

--- a/gimmemotifs/orthologs.py
+++ b/gimmemotifs/orthologs.py
@@ -44,6 +44,7 @@ def motif2factor_from_orthologs(
     database_references: List[str] = None,
     extra_orthologs_references: List[str] = None,
     new_reference: List[str] = None,
+    genomes_dir: str = None,
     tmpdir: str = None,
     keep_intermediate: bool = False,
     outdir: str = ".",
@@ -82,7 +83,7 @@ def motif2factor_from_orthologs(
 
     # Check if we can write output before we do a lot of work
     os.makedirs(outdir, exist_ok=True)
-
+    genomepy_genomes_dir = get_genomes_dir(genomes_dir, check_exist=False)
     tmpdir = tempfile.mkdtemp() if tmpdir is None else tmpdir
 
     logger.info(f"Making a new reference for: {' & '.join(new_reference)}.")
@@ -92,15 +93,17 @@ def motif2factor_from_orthologs(
     logger.info(
         f"For better orthology inference we are also using these assemblies: {' & '.join(extra_orthologs_references)}."
     )
-    logger.info(f"Using strategy: {strategy} for orthology/name inference.")
+    logger.info(f"Using '{strategy}' strategy for orthology/name inference.")
+    logger.info(f"genomes_dir: {genomepy_genomes_dir}.")
     logger.info(f"tmpdir: {tmpdir}.")
     logger.info(f"outdir: {outdir}.")
 
-    all_genomes = set(database_references + extra_orthologs_references + new_reference)
+    # ignore file paths, we search only in the genomepy_genomes_dir
+    all_genomes = [os.path.basename(g) for g in set(database_references + extra_orthologs_references + new_reference)]
 
     # download all required genomes
     logger.info("Downloading all assemblies.")
-    _download_genomes_with_annot(all_genomes, tmpdir)
+    _download_genomes_with_annot(all_genomes, genomepy_genomes_dir, tmpdir)
 
     # convert each genome + annotation into the primary genes (longest protein per gene)
     logger.info("Taking the longest protein per gene per assembly.")
@@ -174,54 +177,57 @@ def _orthofinder(peptide_folder, threads):
     return orthofinder_result
 
 
-def _download_genomes_with_annot(genomes, genomes_dir):
+def _prepare_genomes_with_annot(genome, genomepy_genomes_dir, tpmdir):
+    # unzip genome and gtf (if needed) and symlink these in the tmpdir
+    fasta = f"{genomepy_genomes_dir}/{genome}/{genome}.fa"
+    anno = f"{genomepy_genomes_dir}/{genome}/{genome}.annotation.gtf"
+    for gp_file in [fasta, anno]:
+        # unzip files if needed
+        if not os.path.exists(gp_file):
+            gzipped_gp_file = gp_file + ".gz"
+            result = subprocess.run(
+                ["gunzip", gzipped_gp_file],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            logger.debug(f"""stdout of gunzip:\n {result.stdout.decode("utf-8")}""")
+            logger.debug(f"""stderr of gunzip:\n {result.stderr.decode("utf-8")}""")
+        # symlink files in tmpdir
+        os.symlink(
+            gp_file,
+            f"{tpmdir}/{genome}/{os.path.basename(gp_file)}",
+        )
+
+
+def _download_genomes_with_annot(genomes, genomepy_genomes_dir, tpmdir):
     # download the genomes
     # add check to see if not already in genomes dir?
-    default_genomes_dir = get_genomes_dir(check_exist=False)
-    logger.debug(f"using default genome dir: {default_genomes_dir}")
+    logger.debug(f"using genomes dir: {genomepy_genomes_dir}")
     existing_genomes = []
     for genome in genomes:
-        os.makedirs(f"{genomes_dir}/{genome}", exist_ok=True)
+        os.makedirs(f"{tpmdir}/{genome}", exist_ok=True)
 
         # first check if the user supplied a pep.fa
-        pep = f"{default_genomes_dir}/{genome}/{genome}.pep.fa"
+        pep = f"{genomepy_genomes_dir}/{genome}/{genome}.pep.fa"
         if os.path.exists(pep):
             logger.info(f"found pep.fa for {genome}, using that one.")
             os.symlink(
                 pep,
-                f"{genomes_dir}/{genome}/{genome}.pep.fa",
+                f"{tpmdir}/{genome}/{genome}.pep.fa",
             )
             existing_genomes.append(genome)
             continue
 
         # check if already in default genomes dir, if so, skip downloading and directly copy
         if all(
-            os.path.exists(f"{default_genomes_dir}/{genome}/{genome}.{extension}")
-            or os.path.exists(f"{default_genomes_dir}/{genome}/{genome}.{extension}.gz")
+            os.path.exists(f"{genomepy_genomes_dir}/{genome}/{genome}.{extension}")
+            or os.path.exists(f"{genomepy_genomes_dir}/{genome}/{genome}.{extension}.gz")
             for extension in ["fa", "annotation.gtf"]
         ):
             logger.info(f"{genome} was already downloaded, using that version.")
-            # if except, probably a continuation from previous run
+            # if except, probably a continuation from previous run or NTFS related issues
             try:
-                os.symlink(
-                    f"{default_genomes_dir}/{genome}/{genome}.fa",
-                    f"{genomes_dir}/{genome}/{genome}.fa",
-                )
-
-                anno = f"{default_genomes_dir}/{genome}/{genome}.annotation.gtf"
-                if os.path.exists(anno):
-                    os.symlink(
-                        f"{default_genomes_dir}/{genome}/{genome}.annotation.gtf",
-                        f"{genomes_dir}/{genome}/{genome}.annotation.gtf",
-                    )
-                elif os.path.exists(f"{anno}.gz"):
-                    shutil.copyfile(
-                        f"{anno}.gz",
-                        f"{genomes_dir}/{genome}/{genome}.annotation.gtf.gz",
-                    )
-                else:
-                    # no annotation found, even if genome already exists
-                    continue
+                _prepare_genomes_with_annot(genome, genomepy_genomes_dir, tpmdir)
                 existing_genomes.append(genome)
             except Exception:
                 pass
@@ -238,18 +244,10 @@ def _download_genomes_with_annot(genomes, genomes_dir):
     # download missing genomes, or genomes with missing annotation
     for genome in download_genomes:
         logger.info(f"Downloading {genome} through genomepy.")
-        genomepy.install_genome(genome, annotation=True, genomes_dir=genomes_dir)
+        genomepy.install_genome(genome, annotation=True, genomes_dir=genomepy_genomes_dir)
 
-    for genome in genomes:
-        gzipped_anno = f"{genomes_dir}/{genome}/{genome}.annotation.gtf.gz"
-        if os.path.exists(gzipped_anno):
-            result = subprocess.run(
-                ["gunzip", gzipped_anno],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-            )
-            logger.debug(f"""stdout of gunzip:\n {result.stdout.decode("utf-8")}""")
-            logger.debug(f"""stderr of gunzip:\n {result.stderr.decode("utf-8")}""")
+    for genome in download_genomes:
+        _prepare_genomes_with_annot(genome, genomepy_genomes_dir, tpmdir)
 
 
 def annot2primpep(genome, outdir):

--- a/gimmemotifs/orthologs.py
+++ b/gimmemotifs/orthologs.py
@@ -99,7 +99,10 @@ def motif2factor_from_orthologs(
     logger.info(f"outdir: {outdir}.")
 
     # ignore file paths, we search only in the genomepy_genomes_dir
-    all_genomes = [os.path.basename(g) for g in set(database_references + extra_orthologs_references + new_reference)]
+    all_genomes = [
+        os.path.basename(g.strip()) for g in
+        set(database_references + extra_orthologs_references + new_reference)
+    ]
 
     # download all required genomes
     logger.info("Downloading all assemblies.")
@@ -245,8 +248,6 @@ def _download_genomes_with_annot(genomes, genomepy_genomes_dir, tpmdir):
     for genome in download_genomes:
         logger.info(f"Downloading {genome} through genomepy.")
         genomepy.install_genome(genome, annotation=True, genomes_dir=genomepy_genomes_dir)
-
-    for genome in download_genomes:
         _prepare_genomes_with_annot(genome, genomepy_genomes_dir, tpmdir)
 
 


### PR DESCRIPTION
with this PR you can specify a custom genomes_dir to find/store your genomepy genomes for `gimme motif2factors`. If no genomes_dir is specified, the functions works the same as before (apart from the minor fixes below).

Lets say I have installed my zebrafish genome in `/bank/genomes/GRCz11/GRCz11.fa`. The command now works with 
`gimme motif2factors --new-reference GRCz11 --genomes_dir /bank/gnomes`
An annotation will be added to the existing `/bank/gnomes/GRCz11` directory. The other genomes will be installed in the same genomes directory `/bank/gnomes`.

Additional fixes:
- if the genome fasta is bgzipped, its unzipped.
- user specified genomes are stripped to their basename (only the genomes dir is checked).