### PR TITLE
added version flag

### DIFF
--- a/gimmemotifs/cli.py
+++ b/gimmemotifs/cli.py
@@ -51,6 +51,9 @@ def cli(sys_args):
         epilog=epilog,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+    parser.add_argument(
+        "-v", "--version", action="version", version=f"GimmeMotifs v{__version__}"
+    )
     subparsers = parser.add_subparsers()  # title='subcommands', metavar="<command>")
 
     # gimme_motifs.py
@@ -721,7 +724,8 @@ def cli(sys_args):
         print("$ gimme motifs <inputfile> <outdir> --known")
         sys.exit(1)
     else:
-        if len(sys_args) == 1:
+        ignored = ["-v", "--version", "-h", "--help"]
+        if len(sys_args) == 1 and sys_args[0] not in ignored:
             print(
                 "\033[93mtype `gimme {} -h` for more details\033[0m\n".format(
                     sys_args[-1]


### PR DESCRIPTION
Tiny PR that adds `gimme -v`/`gimme --version` to the CLI.
The version is also printed when running a bare `gimme`, but `func -v` is one of those default commands, so whatever :)