### PR TITLE
Catch correct subprocess error on installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ class build_tools(my_build_py):
             arch = "x86_64"
             try:
                 sp.check_call(f"src/MotifSampler/MotifSampler_{arch}")
-            except sp.CalledProcessError as e:
+            except Exception as e:
                 if "died" in str(e):
                     arch = "i386"
 

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ class build_tools(my_build_py):
             arch = "x86_64"
             try:
                 sp.check_call(f"src/MotifSampler/MotifSampler_{arch}")
-            except Exception as e:
+            except (sp.CalledProcessError, OSError) as e:
                 if "died" in str(e):
                     arch = "i386"
 


### PR DESCRIPTION
According to the `subprocess` docs:

> If `check_call()` was unable to start the process it will propagate the exception that was raised.

On my machine, the included MotifSampler binary is not valid, so the module never even gets to raising a `CalledProcessError`. Instead I get an unhandled `OSError`.

This fixes the problem for me, but perhaps you'd prefer an approach that more explicitly calls out the Exception type?

Fixes #235