### PR TITLE
fix apostrophe in gene name

### DIFF
--- a/gimmemotifs/orthologs.py
+++ b/gimmemotifs/orthologs.py
@@ -431,6 +431,7 @@ def load_orthogroups_in_db(db, genomes, orthofinder_result):
             for gene in genes.split(", "):
                 # for each gene we store its gene_name (if present,
                 # otherwise .) and gene_id. We load them both in the database.
+                gene = gene.replace("'", "")
                 gene_name, gene_id = gene.split("|")
                 if gene_name != ".":
                     conn.execute(
@@ -449,6 +450,7 @@ def load_orthogroups_in_db(db, genomes, orthofinder_result):
 
             # for each gene we store its gene_name (if present,
             # otherwise .) and gene_id. We load them both in the database.
+            gene = gene.replace("'", "")
             gene_name, gene_id = gene.split("|")
             if gene_name != ".":
                 conn.execute(


### PR DESCRIPTION
dm6 has apostrophes in its gene names....

https://www.uniprot.org/uniprot/O62621: `beta'COP`

That breaks the sql grammar, so let's throw away the apostrophes :smile: 