### PR TITLE
require motifs to have unique ids when clustering

### DIFF
--- a/gimmemotifs/cluster.py
+++ b/gimmemotifs/cluster.py
@@ -132,6 +132,10 @@ def cluster_motifs(
     if type([]) != type(motifs):
         motifs = read_motifs(motifs, fmt="pfm")
 
+    # All motifs must have unique ids, used in dictionary below
+    motif_ids = list(map(lambda x: x.id, motifs))
+    assert len(motif_ids) == len(set(motif_ids)), "Motif ids must be unique"
+
     mc = MotifComparer()
 
     # Trim edges with low information content

--- a/gimmemotifs/cluster.py
+++ b/gimmemotifs/cluster.py
@@ -133,8 +133,7 @@ def cluster_motifs(
         motifs = read_motifs(motifs, fmt="pfm")
 
     # All motifs must have unique ids, used in dictionary below
-    motif_ids = list(map(lambda x: x.id, motifs))
-    assert len(motif_ids) == len(set(motif_ids)), "Motif ids must be unique"
+    assert len(motif_ids) == len({motif.id for motif in motifs}), "Motif ids must be unique"
 
     mc = MotifComparer()
 

--- a/gimmemotifs/cluster.py
+++ b/gimmemotifs/cluster.py
@@ -133,7 +133,8 @@ def cluster_motifs(
         motifs = read_motifs(motifs, fmt="pfm")
 
     # All motifs must have unique ids, used in dictionary below
-    assert len(motif_ids) == len({motif.id for motif in motifs}), "Motif ids must be unique"
+    motif_ids = [motif.id for motif in motifs]
+    assert len(motif_ids) == len(set(motif_ids)), "Motif ids must be unique"
 
     mc = MotifComparer()
 


### PR DESCRIPTION
Clustering fails when motif ids are not set. At https://github.com/vanheeringen-lab/gimmemotifs/blob/master/gimmemotifs/cluster.py#L147 a dictionary is created based on the motif ids, so these keys should be required to be unique.