### PR TITLE
Use .annotation_bed_file attribute of Genome

### DIFF
--- a/gimmemotifs/motif/denovo.py
+++ b/gimmemotifs/motif/denovo.py
@@ -246,7 +246,6 @@ def create_background(
         f = MatchedGcFasta(fafile, genome, nr_times * len(fg))
         logger.debug(f"GC matched background: {outfile}")
     elif bg_type == "promoter":
-        fname = Genome(genome).filename
         gene_file = Genome(genome).annotation_bed_file
         if not gene_file:
             gene_file = os.path.join(config.get_gene_dir(), f"{genome}.bed")

--- a/gimmemotifs/motif/denovo.py
+++ b/gimmemotifs/motif/denovo.py
@@ -247,7 +247,7 @@ def create_background(
         logger.debug(f"GC matched background: {outfile}")
     elif bg_type == "promoter":
         fname = Genome(genome).filename
-        gene_file = fname.replace(".fa", ".annotation.bed.gz")
+        gene_file = Genome(genome).annotation_bed_file
         if not gene_file:
             gene_file = os.path.join(config.get_gene_dir(), f"{genome}.bed")
         if not os.path.exists(gene_file):


### PR DESCRIPTION
A fix to use the `.annotation_bed_file` attribute of genomepy `Genome` object, instead of hardcoded `.fa` to `.bed.gz` replacement which does not work when only a non-compressed annotation file ( for example `hg38.annotation.bed` ) is available.