### PR TITLE
use malloc

### DIFF
--- a/gimmemotifs/c_metrics.c
+++ b/gimmemotifs/c_metrics.c
@@ -732,8 +732,8 @@ static PyObject * c_metrics_pfmscan(PyObject *self, PyObject * args)
 
         // Scan sequence
         int j_max = seq_len - pwm_len + 1;
-        double score_matrix[j_max];
-        double rc_score_matrix[j_max];
+        double *score_matrix = malloc(size);
+        double *rc_score_matrix = malloc(size);
         double score, rc_score;
 
         if (j_max < 0) { j_max = 0;}
@@ -784,6 +784,9 @@ static PyObject * c_metrics_pfmscan(PyObject *self, PyObject * args)
 		for (j = 0; j < j_max; j++) {
     			PyList_SetItem(return_list, j, PyFloat_FromDouble(score_matrix[j]));
 		}
+		
+		free(score_matrix);
+		free(rc_score_matrix);
 	    	return return_list;
 	}
 
@@ -836,6 +839,7 @@ static PyObject * c_metrics_pfmscan(PyObject *self, PyObject * args)
 			}
 		}
 	}
+	free(score_matrix);
 
 	if (scan_rc) {
 		for (j = 0; j < j_max; j++) {
@@ -873,6 +877,7 @@ static PyObject * c_metrics_pfmscan(PyObject *self, PyObject * args)
 			}
 		}
 	}
+	free(rc_score_matrix);
 
 	for (i = 0; i < n_report; i++) {
 		if (maxPos[i] > - 1) {

--- a/gimmemotifs/c_metrics.c
+++ b/gimmemotifs/c_metrics.c
@@ -732,6 +732,7 @@ static PyObject * c_metrics_pfmscan(PyObject *self, PyObject * args)
 
         // Scan sequence
         int j_max = seq_len - pwm_len + 1;
+	long size = j_max * sizeof(double);
         double *score_matrix = malloc(size);
         double *rc_score_matrix = malloc(size);
         double score, rc_score;


### PR DESCRIPTION
C function `pfmscan()` will now store the intermediate scores in the heap (the RAM I think, this is my first tangle with C).

With my test FASTA, two arrays are created that are way bigger than the stack size. We could store these arrays on the heap, at the cost of speed. However, if the length of the sequences are normally not that large, we could also throw an error/warning instead.

Note: One thing that I could not get to work, is dynamically deciding to use the stack/heap (you cannot declare a variable inside an if-else in C, and then use it outside the if-else).

How to test:

Command line:
```bash
git clone git@github.com:vanheeringen-lab/gimmemotifs.git
cd gimmemotifs
git checkout option_1
python setup.py build && pip install .
```

Python:
```python
from gimmemotifs.motif import Motif, read_motifs
from gimmemotifs.fasta import Fasta


jaspar_motif_file="data/motif_databases/JASPAR2022_vertebrates.pfm"
motifs = read_motifs(jaspar_motif_file)
print(len([m for m in motifs if m.id.startswith("MA0046.2")]))  # prints 1

m = [m for m in motifs if m.id.startswith("MA0046.2")][0]
print(m.id)  # prints 'MA0046.2_MA0046.2.HNF1A'

ff = "test/data/scan/genome/scan_test.fa"  # segfault

f = Fasta(ff)
m.scan_all(f)
```