### PR TITLE
skip short seqs

### DIFF
--- a/gimmemotifs/c_metrics.c
+++ b/gimmemotifs/c_metrics.c
@@ -711,8 +711,6 @@ static PyObject * c_metrics_pfmscan(PyObject *self, PyObject * args)
 
         seq_len = strlen(seq);
         pwm_len = PyList_Size(pfm_o);
-        if (seq_len < pwm_len) {
-            printf ("\nSequence shorter than the motif!\n");
             PyObject*  return_list = PyList_New(0);
             return return_list;
         }

--- a/gimmemotifs/c_metrics.c
+++ b/gimmemotifs/c_metrics.c
@@ -705,14 +705,19 @@ static PyObject * c_metrics_pfmscan(PyObject *self, PyObject * args)
         if (!PyArg_ParseTuple(args, "sOOii|i", &seq, &pfm_o, &cutoff_o, &n_report, &scan_rc, &return_all))
                 return NULL;
 
-        seq_len = strlen(seq);
-
         // Retrieve frequency matrix
         if (!PyList_Check(pfm_o))
                 return NULL;
 
-        // Weight matrices
+        seq_len = strlen(seq);
         pwm_len = PyList_Size(pfm_o);
+        if (seq_len < pwm_len) {
+            printf ("\nSequence shorter than the motif!\n");
+            PyObject*  return_list = PyList_New(0);
+            return return_list;
+        }
+	
+        // Weight matrices
         double pfm[pwm_len][4];
         double pwm[pwm_len][4];
         fill_matrix(pfm, pfm_o);

--- a/gimmemotifs/c_metrics.c
+++ b/gimmemotifs/c_metrics.c
@@ -711,6 +711,7 @@ static PyObject * c_metrics_pfmscan(PyObject *self, PyObject * args)
 
         seq_len = strlen(seq);
         pwm_len = PyList_Size(pfm_o);
+	if (seq_len < pwm_len) {
             PyObject*  return_list = PyList_New(0);
             return return_list;
         }

--- a/gimmemotifs/c_metrics.c
+++ b/gimmemotifs/c_metrics.c
@@ -711,9 +711,9 @@ static PyObject * c_metrics_pfmscan(PyObject *self, PyObject * args)
 
         seq_len = strlen(seq);
         pwm_len = PyList_Size(pfm_o);
-	if (seq_len < pwm_len) {
-            PyObject*  return_list = PyList_New(0);
-            return return_list;
+	    if (seq_len < pwm_len) {
+                PyObject*  return_list = PyList_New(0);
+                return return_list;
         }
 	
         // Weight matrices


### PR DESCRIPTION
C function `pfmscan()` will now stop if the given sequence is shorter than the given pfm.

I'm not sure if this does anything other than stopping early, because the line `if (j_max < 0) { j_max = 0;}`, in line 739 (743 in this PR), should already take care of problems?

How to test:

Command line:
```bash
git clone git@github.com:vanheeringen-lab/gimmemotifs.git
cd gimmemotifs
git checkout option_2
python setup.py build && pip install .
```

Python:
```python
from gimmemotifs.c_metrics import pfmscan

seq = "ATGGTCT"
# ppm and cutoff for 'MA0046.2_MA0046.2.HNF1A'
ppm = [[0.3681, 0.1725, 0.2467, 0.2127],
       [0.4593, 0.0273, 0.4716, 0.0418],
       [0.0228, 0.0643, 0.0548, 0.8581],
       [0.1474, 0.1097, 0.0275, 0.7154],
       [0.9817, 0.0002, 0.0171, 0.001],
       [0.9337, 0.0418, 0.0005, 0.024],
       [0.0804, 0.0267, 0.0004, 0.8925],
       [0.2361, 0.265, 0.3209, 0.178],
       [0.934, 0.0006, 0.0224, 0.043],
       [0.0452, 0.0008, 0.0538, 0.9002],
       [0.0029, 0.0158, 0.0003, 0.981],
       [0.815, 0.0137, 0.077, 0.0943],
       [0.8781, 0.0431, 0.068, 0.0108],
       [0.0865, 0.8223, 0.0381, 0.0531],
       [0.2807, 0.2422, 0.1608, 0.3163]]
c = 9.687735324685306
nreport = 50
scan_rc = True

result = pfmscan(seq.upper(), ppm, c, nreport, scan_rc)
print(result)

```