### PR TITLE
not too short, not too long

### DIFF
--- a/gimmemotifs/c_metrics.c
+++ b/gimmemotifs/c_metrics.c
@@ -717,8 +717,7 @@ static PyObject * c_metrics_pfmscan(PyObject *self, PyObject * args)
     }
 
     // Cutoff for every spacer length
-    double cutoff;
-    cutoff = PyFloat_AsDouble(cutoff_o);
+    double cutoff = PyFloat_AsDouble(cutoff_o);
 
     // Scan sequence
     int seq_len = strlen(seq);
@@ -773,7 +772,6 @@ static PyObject * c_metrics_pfmscan(PyObject *self, PyObject * args)
                     rc_score += pwm_min;
                     break;
 			}
-		
 		}
 		score_matrix[j] = score;
 		rc_score_matrix[j] = rc_score;


### PR DESCRIPTION
The original code already skips sequences that are too short (`if (j_max < 0) { j_max = 0;}`). Could be combined with #304 for slightly faster rejection.

This PR prints a message and returns an empty list if the sequence is too long to compute everything in the stack. We could also compute everything in the heap (code is there, just commented out). With some very rudimentary testing, the time loss of using the heap seems ~2%.

Finally, I fixed the linting and compilation warnings that were bugging me.