### PR TITLE
fix: types and field consistency in `c_metrics` module

### DIFF
--- a/gimmemotifs/c_metrics.c
+++ b/gimmemotifs/c_metrics.c
@@ -312,7 +312,7 @@ static PyObject * c_metrics_score(PyObject *self, PyObject * args)
 
 }
 
-int get_truncate_len(len1, len2, pos) {
+int get_truncate_len(int len1, int len2, int pos) {
 	// 
 	
 	if (pos < 0) {

--- a/gimmemotifs/c_metrics.c
+++ b/gimmemotifs/c_metrics.c
@@ -898,7 +898,7 @@ static PyMethodDef CoreMethods[] = {
 	{"c_max_subtotal", c_metrics_max_subtotal, METH_VARARGS,"Test"},
 	{"pfmscan", c_metrics_pfmscan, METH_VARARGS,"Test"},
 	{"pwmscan", c_metrics_pwmscan, METH_VARARGS,"Test"},
-	{NULL, NULL, NULL, 0, NULL}
+	{NULL, NULL, 0, NULL}
 };
 
 #if PY_MAJOR_VERSION >= 3

--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,7 @@ setup(
         "setuptools >=0.7",
         # copied from the requirements.yaml
         "biofluff >=3.0.4",
-        "configparser",
+        "configparser <6.0.0",
         "diskcache",
         "feather-format",
         "genomepy >=0.13.0",


### PR DESCRIPTION
This pull request fixes two issues in `c_metrics`. 
- [x] add types to all inputs of the `get_truncate_len` function, which previously lacked them. 
- [x] remove an extra field from the `CoreMethods` array sentinel.

I also had to bound `configparser` to be less than the [latest `6.0.0` release](https://pypi.org/project/configparser/6.0.0/) to build the package, but this should be able to be removed once it's incompatibility with versioneer or other packages is resolved.