### PR TITLE
306Update report.py

### DIFF
--- a/gimmemotifs/report.py
+++ b/gimmemotifs/report.py
@@ -1045,7 +1045,7 @@ def roc_html_report(
                 .align(subset=bar_cols, location="center")
                 .rename(columns=rename_columns)
                 .to_precision_str(subset=["% matches input", "% matches background"])
-                .render()
+                .to_html()
             )
         else:
             f.write("<body>No enriched motifs found.</body>")


### PR DESCRIPTION
Adressing #306 and #322

This should fix the report generation.

There are some other deprecation warnings around pandas that might soon break the package soon. Don't have the time to fix them, but I'm dumping them here:

```
python_env/lib/python3.10/site-packages/pandas/core/frame.py:10517: FutureWarning: DataFrame.applymap has been deprecated. Use DataFrame.map instead.
  warnings.warn(
python_env/lib/python3.10/site-packages/pandas/core/indexing.py:911: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise in a future error of pandas. Value '['6' '6' '21' '20' '20' '5' '4' '20' '20' '9' '8' '12' '5' '4' '8' '5'
 '21' '5' '7' '6' '7' '8' '8' '7' '6' '4' '5' '3' '5' '5' '5' '4' '4' '7'
 '3' '5' '5' '7' '3' '4' '4' '4' '3' '3' '4' '5' '7' '3' '3' '4' '4' '7'
 '4' '5' '5' '3' '4' '3' '4' '3' '3' '3' '4' '3' '4' '3' '3' '4' '3' '3']' has dtype incompatible with int64, please explicitly cast to a compatible dtype first.
  iloc._setitem_with_indexer(indexer, value, self.name)
python_env/lib/python3.10/site-packages/pandas/core/indexing.py:911: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise in a future error of pandas. Value '['<1' '<1' '5' '5' '5' '<1' '<1' '5' '5' '<1' '3' '<1' '<1' '<1' '<1' '<1'
 '5' '<1' '2' '<1' '<1' '<1' '<1' '<1' '<1' '<1' '<1' '<1' '<1' '<1' '<1'
 '<1' '<1' '2' '<1' '<1' '<1' '2' '<1' '<1' '<1' '<1' '<1' '<1' '<1' '<1'
 '2' '<1' '<1' '<1' '<1' '<1' '<1' '2' '<1' '<1' '<1' '<1' '<1' '<1' '<1'
 '<1' '<1' '<1' '<1' '<1' '<1' '<1' '<1' '<1']' has dtype incompatible with int64, please explicitly cast to a compatible dtype first.
  iloc._setitem_with_indexer(indexer, value, self.name)
python_env/lib/python3.10/site-packages/pandas/core/frame.py:10517: FutureWarning: DataFrame.applymap has been deprecated. Use DataFrame.map instead.
  warnings.warn(
python_env/lib/python3.10/site-packages/pandas/core/indexing.py:911: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise in a future error of pandas. Value '['6' '5' '12' '5' '5']' has dtype incompatible with int64, please explicitly cast to a compatible dtype first.
  iloc._setitem_with_indexer(indexer, value, self.name)
python_env/lib/python3.10/site-packages/pandas/core/indexing.py:911: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise in a future error of pandas. Value '['<1' '<1' '<1' '<1' '<1']' has dtype incompatible with int64, please explicitly cast to a compatible dtype first.
  iloc._setitem_with_indexer(indexer, value, self.name)
2025-02-24 16:17:19,871 - INFO - gimme motifs final report: gimme.motifs.html
```